### PR TITLE
for simplified-SDC, eliminate a temporary ydot_react array

### DIFF
--- a/integration/VODE/vode_rhs_simplified_sdc.H
+++ b/integration/VODE/vode_rhs_simplified_sdc.H
@@ -54,13 +54,11 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
 
     // call the specific network to get the RHS
 
-    YdotNetArray1D ydot_react = {0};
-
-    actual_rhs(state, ydot_react);
+    actual_rhs(state, ydot);
 
 #ifdef NONAKA_PLOT
     if (! in_jacobian) {
-        nonaka_rhs(time, state, ydot_react);
+        nonaka_rhs(time, state, ydot);
     }
 #endif
 
@@ -70,13 +68,13 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
         // the correct size here is the size of the reactive state RHS,
         // not the SDC state RHS (neqs, not VODE_NEQS)
         for (int n = 1; n <= neqs; ++n) {
-            ydot_react(n) *= react_boost;
+            ydot(n) *= react_boost;
         }
     }
 
     // convert back to the vode type -- this will add the advective terms
 
-    rhs_to_vode(time, state, ydot_react, vode_state, ydot);
+    rhs_to_vode(time, state, vode_state, ydot);
 
 }
 

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -332,11 +332,11 @@ void rhs_to_vode(const Real time, burn_t& state,
 
 #if defined(SDC_EVOLVE_ENERGY)
 
-    ydot(SEINT+1) += state.rho * ydot_react(net_ienuc);
+    ydot(SEINT+1) += state.rho * ydot(net_ienuc);
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    ydot(SENTH+1) += state.rho * ydot_react(net_ienuc);
+    ydot(SENTH+1) += state.rho * ydot(net_ienuc);
 
 #endif
 

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -346,7 +346,7 @@ void rhs_to_vode(const Real time, burn_t& state,
     // Note: both ydot is 1-based
 
     for (int n = 0; n < SVAR_EVOLVE; n++) {
-        ydot(n+1) = state.ydot_a[n];
+        ydot(n+1) += state.ydot_a[n];
     }
 
 }

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -323,16 +323,20 @@ void rhs_to_vode(const Real time, burn_t& state,
     BL_ASSERT(SFS == 0);
 
     for (int n = 1; n <= NumSpec; n++) {
-        ydot(SFS+n) += state.rho * aion[n-1] * ydot(n);
+        ydot(SFS+n) = state.rho * aion[n-1] * ydot(n);
     }
+
+    // rescale the energy to be d(rho e)/dt
 
 #if defined(SDC_EVOLVE_ENERGY)
 
-    ydot(SEINT+1) += state.rho * ydot(net_ienuc);
+    BL_ASSERT(SEINT+1 == net_ienuc);
+
+    ydot(SEINT+1) *= state.rho;
 
 #elif defined(SDC_EVOLVE_ENTHALPY)
 
-    ydot(SENTH+1) += state.rho * ydot(net_ienuc);
+    ydot(SENTH+1) *= state.rho;
 
 #endif
 

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -312,27 +312,22 @@ void vode_to_burn(const Real time, const dvode_t& vode_state, burn_t& state)
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void rhs_to_vode(const Real time, burn_t& state,
-                 YdotNetArray1D& ydot_react, dvode_t& vode_state,
+                 dvode_t& vode_state,
                  RArray1D& ydot)
 {
 
 
-    // ydot_react has just the contribution to the RHS from the
+    // on input, ydot has the contributions to the RHS from the
     // reaction network.  Note that these are in terms of dY/dt
+    // we will convert these in place to the form needed for SDC
 
-    // start with the contribution from the non-reacting sources
+    // convert from dY/dt to dX/dt. The species derivatives are the
+    // first NumSpec components of ydot coming from the reaction network
 
-    // Note: both ydot and ydot_react are 1-based
-    for (int n = 0; n < SVAR_EVOLVE; n++) {
-        ydot(n+1) = state.ydot_a[n];
-    }
-
-    // add in the reacting terms -- here we convert from dY/dt to dX/dt
-    // The species derivatives are the first NumSpec components of
-    // ydot_react
+    BL_ASSERT(SFS == 0);
 
     for (int n = 1; n <= NumSpec; n++) {
-        ydot(SFS+n) += state.rho * aion[n-1] * ydot_react(n);
+        ydot(SFS+n) += state.rho * aion[n-1] * ydot(n);
     }
 
 #if defined(SDC_EVOLVE_ENERGY)
@@ -344,6 +339,15 @@ void rhs_to_vode(const Real time, burn_t& state,
     ydot(SENTH+1) += state.rho * ydot_react(net_ienuc);
 
 #endif
+
+    // now add the contribution from the non-reacting sources --
+    // including advection
+
+    // Note: both ydot is 1-based
+
+    for (int n = 0; n < SVAR_EVOLVE; n++) {
+        ydot(n+1) = state.ydot_a[n];
+    }
 
 }
 

--- a/sphinx_docs/source/eos.rst
+++ b/sphinx_docs/source/eos.rst
@@ -209,6 +209,46 @@ appropriate interpolation table from that site to use this.
 Interface and Modes
 ===================
 
+The EOS is called as:
+
+.. code:: c++
+
+   eos(mode, eos_type)
+
+where *mode* determines which thermodynamic quantities are inputs,
+and is one of:
+
+* ``eos_input_rt`` : density and temperature are inputs
+
+* ``eos_input_rh`` : density and specific enthalpy are inputs
+
+* ``eos_input_tp`` : temperature and pressure are inputs
+
+* ``eos_input_rp`` : density and pressure are inputs
+
+* ``eos_input_re`` : density and specific internal energy are inputs
+
+* ``eos_input_ps`` : pressure and entropy are inputs
+
+* ``eos_input_ph`` : pressure and specific enthalpy are inputs
+
+* ``eos_input_th`` : temperature and specific enthalpy are inputs
+
+The *eos_type* passed in is one of
+
+* ``eos_t`` : provides access to all available thermodynamic information,
+  including derivatives.
+
+* ``eos_re_t`` : only provides the energy-based thermodynamic information, including
+  energy derivatives.
+
+* ``eos_rep_t`` : expands on ``eos_re_t`` to include pressure information
+
+In general, you should use the type that has the smallest set of
+information needed, since we optimize out needless quantities at
+compile type (via C++ templating) for ``eos_re_t`` and ``eos_rep_t``.
+
+
 Initialization and Cutoff Values
 ================================
 


### PR DESCRIPTION
since we have shifted such that the SDC VODE state is in the same
order as Strang, we no longer need a temporary.  This frees up
memory and a potentially expensive copy.

This can give roundoff diffs