### PR TITLE
add a rate_low_cutoff_temp parameter

### DIFF
--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -1,6 +1,10 @@
 # This is the main include makefile for applications that want to use Microphysics
 # You should set NETWORK_OUTPUT_PATH before including this file
 
+# for backwards compatibility for any application code that still looks for this
+
+DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
+
 ifeq ($(USE_SIMPLIFIED_SDC), TRUE)
   DEFINES += -DSIMPLIFIED_SDC
 else ifeq ($(USE_TRUE_SDC), TRUE)

--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -73,7 +73,7 @@ void clean_state (burn_t& state)
 
     // Ensure that the temperature always stays within reasonable limits.
 
-    state.T = amrex::min(MAX_TEMP, amrex::max(state.T, EOSData::mintemp));
+    state.T = amrex::min(ReactData::maxtemp, amrex::max(state.T, EOSData::mintemp));
 
 }
 

--- a/integration/QSS/actual_integrator.H
+++ b/integration/QSS/actual_integrator.H
@@ -25,7 +25,7 @@ void clean_state (burn_t& state)
 
     // Ensure that the temperature always stays within reasonable limits.
 
-    state.T = amrex::min(MAX_TEMP, amrex::max(state.T, EOSData::mintemp));
+    state.T = amrex::min(ReactData::maxtemp, amrex::max(state.T, EOSData::mintemp));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/integration/VODE/vode_rhs.H
+++ b/integration/VODE/vode_rhs.H
@@ -47,7 +47,7 @@ void rhs (const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, c
     // Only do the burn if the incoming temperature is within the temperature
     // bounds. Otherwise set the RHS to zero and return.
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP) {
+    if (state.T <= EOSData::mintemp || state.T >= ReactData::maxtemp || state.T <= ReactData::mintemp) {
 
         for (int n = 1; n <= VODE_NEQS; ++n) {
             ydot(n) = 0.0_rt;
@@ -112,7 +112,7 @@ void jac (burn_t& state, dvode_t& vode_state, MatrixType& pd)
     // Only do the burn if the incoming temperature is within the temperature
     // bounds. Otherwise set the Jacobian to zero and return.
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP) {
+    if (state.T <= EOSData::mintemp || state.T >= ReactData::maxtemp || state.T <= ReactData::mintemp) {
 
         for (int j = 1; j <= VODE_NEQS; ++j) {
             for (int i = 1; i <= VODE_NEQS; ++i) {

--- a/integration/VODE/vode_rhs_simplified_sdc.H
+++ b/integration/VODE/vode_rhs_simplified_sdc.H
@@ -53,7 +53,7 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
     // below the minimum temperature for evaluating rates, we still
     // want to include the advection, so just zero the rates here.
 
-    if (state.T > ReactData::min_temp) {
+    if (state.T > ReactData::mintemp) {
         actual_rhs(state, ydot);
     } else {
         for (int n = 1; n <= VODE_NEQS; ++n) {

--- a/integration/VODE/vode_rhs_simplified_sdc.H
+++ b/integration/VODE/vode_rhs_simplified_sdc.H
@@ -38,7 +38,7 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
 
     // make sure that the temperature is valid
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP) {
+    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP || state.T <= rate_cutoff_temp) {
 
         for (int n = 1; n <= VODE_NEQS; ++n) {
             ydot(n) = 0.0_rt;
@@ -104,10 +104,10 @@ void jac (burn_t& state, dvode_t& vode_state, MatrixType& pd)
     vode_to_burn(vode_state.tn, vode_state, state);
 
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP) {
+    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP || state.T <= rate_cutoff_temp) {
 
-        for (int j = 1; j <= VODE_NEQS; ++j) {
-            for (int i = 1; i <= VODE_NEQS; ++i) {
+        for (int i = 1; i <= VODE_NEQS; ++i) {
+            for (int j = 1; j <= VODE_NEQS; ++j) {
                 pd(i,j) = 0.0_rt;
             }
         }

--- a/integration/VODE/vode_rhs_simplified_sdc.H
+++ b/integration/VODE/vode_rhs_simplified_sdc.H
@@ -36,9 +36,10 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
 
     vode_to_burn(time, vode_state, state);
 
-    // make sure that the temperature is valid
+    // make sure that the temperature is valid -- return zero for
+    // everything if the temperature are just wrong
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP || state.T <= rate_cutoff_temp) {
+    if (state.T <= EOSData::mintemp || state.T >= ReactData::maxtemp) {
 
         for (int n = 1; n <= VODE_NEQS; ++n) {
             ydot(n) = 0.0_rt;
@@ -48,9 +49,17 @@ void rhs(const Real time, burn_t& state, dvode_t& vode_state, RArray1D& ydot, co
 
     }
 
-    // call the specific network to get the RHS
+    // call the specific network to get the RHS.  However, if we are
+    // below the minimum temperature for evaluating rates, we still
+    // want to include the advection, so just zero the rates here.
 
-    actual_rhs(state, ydot);
+    if (state.T > ReactData::min_temp) {
+        actual_rhs(state, ydot);
+    } else {
+        for (int n = 1; n <= VODE_NEQS; ++n) {
+            ydot(n) = 0.0_rt;
+        }
+    }
 
 #ifdef NONAKA_PLOT
     if (! in_jacobian) {
@@ -102,7 +111,7 @@ void jac (burn_t& state, dvode_t& vode_state, MatrixType& pd)
     vode_to_burn(vode_state.tn, vode_state, state);
 
 
-    if (state.T <= EOSData::mintemp || state.T >= MAX_TEMP || state.T <= rate_cutoff_temp) {
+    if (state.T <= EOSData::mintemp || state.T >= ReactData::maxtemp || state.T <= ReactData::mintemp) {
 
         for (int i = 1; i <= VODE_NEQS; ++i) {
             for (int j = 1; j <= VODE_NEQS; ++j) {

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -17,7 +17,7 @@ integrate_energy         logical   .true.
 # 3 == Numerical for reactions; analytic for primitive -> conserved (simplified-SDC only)
 jacobian                 integer   1
 
-# Should we print out diagnostic output after the solve?  
+# Should we print out diagnostic output after the solve?
 burner_verbose           logical   .false.
 
 # Tolerances for the solver (relative and absolute), for the
@@ -47,6 +47,9 @@ SMALL_X_SAFE                 real            1.0d-30
 
 # The maximum temperature for reactions in the integration.
 MAX_TEMP                     real            1.0d11
+
+# The temperature below which we zero out the rates (for simplified-SDC)
+rate_cutoff_temp             real            -1.0
 
 # boost the reaction rates by a factor > 1
 react_boost                 real         -1.d0

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -49,7 +49,7 @@ SMALL_X_SAFE                 real            1.0d-30
 MAX_TEMP                     real            1.0d11
 
 # The temperature below which we zero out the rates (for simplified-SDC)
-rate_cutoff_temp             real            -1.0
+react_low_cutoff_temp             real            -1.0
 
 # boost the reaction rates by a factor > 1
 react_boost                 real         -1.d0

--- a/integration/utils/numerical_jacobian.H
+++ b/integration/utils/numerical_jacobian.H
@@ -55,7 +55,13 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
     // default -- plus convert the dY/dt into dX/dt
 
-    actual_rhs(state, ydotm);
+    if (state.T > ReactData::mintemp) {
+        actual_rhs(state, ydotm);
+    } else {
+        for (int i = 1; i <= neqs; ++i) {
+            ydotm(i) = 0.0_rt;
+        }
+    }
 
     for (int q = 1; q <= NumSpec; q++) {
         ydotm(q) *= aion[q-1];
@@ -104,7 +110,14 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
         state_delp.xn[n-1] += dy;
 
-        actual_rhs(state_delp, ydotp);
+        if (state_delp.T > ReactData::mintemp) {
+            actual_rhs(state_delp, ydotp);
+        } else {
+            for (int i = 1; i <= neqs; ++i) {
+                ydotp(i) = 0.0_rt;
+            }
+        }
+
 
         // We integrate X, so convert from the Y we got back from the RHS
 
@@ -129,7 +142,7 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
     state_delp.T += dy;
 
-    if (state_delp.T <= EOSData::mintemp || state_delp.T >= MAX_TEMP) {
+    if (state_delp.T <= EOSData::mintemp || state_delp.T >= ReactData::maxtemp) {
 
         for (int i = 1; i <= neqs; i++) {
             for (int j = 1; j <= neqs; j++) {
@@ -149,7 +162,13 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
     eos(eos_input_rt, state_delp);
 
-    actual_rhs(state_delp, ydotp);
+    if (state.delp > ReactData::smalltemp) {
+        actual_rhs(state_delp, ydotp);
+    } else {
+        for (int i = 1; i <= neqs; ++i) {
+            ydotp(i) = 0.0_rt;
+        }
+    }
 
     for (int q = 1; q <= NumSpec; q++) {
         ydotp(q) *= aion[q-1];

--- a/integration/utils/numerical_jacobian.H
+++ b/integration/utils/numerical_jacobian.H
@@ -162,7 +162,7 @@ void numerical_jac(burn_t& state, const jac_info_t& jac_info, JacNetArray2D& jac
 
     eos(eos_input_rt, state_delp);
 
-    if (state.delp > ReactData::smalltemp) {
+    if (state_delp.T > ReactData::mintemp) {
         actual_rhs(state_delp, ydotp);
     } else {
         for (int i = 1; i <= neqs; ++i) {

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -6,6 +6,7 @@ CEXE_headers += eos_type.H
 CEXE_headers += eos_override.H
 
 CEXE_sources += eos_data.cpp
+CEXE_sources += react_data.cpp
 
 CEXE_headers += network.H
 CEXE_headers += rhs_type.H

--- a/interfaces/network.H
+++ b/interfaces/network.H
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <network_properties.H>
+#include <react_data.H>
 
 void network_init();
 

--- a/interfaces/network_initialization.cpp
+++ b/interfaces/network_initialization.cpp
@@ -1,5 +1,6 @@
 #ifdef REACTIONS
 #include <actual_network.H>
+#include <react_data.H>
 #ifdef NEW_NETWORK_IMPLEMENTATION
 #include <rhs.H>
 #else
@@ -15,13 +16,15 @@
 void network_init()
 {
 
-ReactData::mintemp = react_low_cutoff_temp;
-ReactData::maxtemp = MAX_TEMP;
-ReactData::initialized = true;
+#ifdef REACTIONS
+    ReactData::mintemp = react_low_cutoff_temp;
+    ReactData::maxtemp = MAX_TEMP;
+    ReactData::initialized = true;
+#endif
 
 #ifdef REACTIONS
 #ifdef NONAKA_PLOT
-nonaka_init();
+    nonaka_init();
 #endif
 #ifdef NEW_NETWORK_IMPLEMENTATION
     actual_network_init();

--- a/interfaces/network_initialization.cpp
+++ b/interfaces/network_initialization.cpp
@@ -1,5 +1,4 @@
 #ifdef REACTIONS
-#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #include <actual_network.H>
 #ifdef NEW_NETWORK_IMPLEMENTATION
 #include <rhs.H>
@@ -10,23 +9,26 @@
 #include <nonaka_plot.H>
 #endif
 #endif
-#endif
+
+#include <extern_parameters.H>
 
 void network_init()
 {
+
+ReactData::mintemp = react_low_cutoff_temp;
+ReactData::maxtemp = MAX_TEMP;
+ReactData::initialized = true;
 
 #ifdef REACTIONS
 #ifdef NONAKA_PLOT
 nonaka_init();
 #endif
-#ifdef NETWORK_HAS_CXX_IMPLEMENTATION
 #ifdef NEW_NETWORK_IMPLEMENTATION
     actual_network_init();
     RHS::rhs_init();
 #else
     actual_network_init();
     actual_rhs_init();
-#endif
 #endif
 #endif
 }

--- a/interfaces/react_data.H
+++ b/interfaces/react_data.H
@@ -1,0 +1,17 @@
+#ifndef REACT_DATA_H
+#define REACT_DATA_H
+
+#include <AMReX.H>
+#include <AMReX_REAL.H>
+
+// store some global limits for when we evaluate reactions rates,
+// set at initialization time
+
+namespace ReactData
+{
+    extern bool initialized;
+    extern AMREX_GPU_MANAGED amrex::Real mintemp;
+    extern AMREX_GPU_MANAGED amrex::Real maxtemp;
+}
+
+#endif

--- a/interfaces/react_data.cpp
+++ b/interfaces/react_data.cpp
@@ -1,0 +1,7 @@
+#include <react_data.H>
+
+// Declare extern variables
+
+bool ReactData::initialized;
+AMREX_GPU_MANAGED amrex::Real ReactData::mintemp;
+AMREX_GPU_MANAGED amrex::Real ReactData::maxtemp;

--- a/networks/ECSN/Make.package
+++ b/networks/ECSN/Make.package
@@ -2,8 +2,6 @@ CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
 
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/_parameters
+++ b/networks/_parameters
@@ -8,3 +8,7 @@ use_tables  logical   .false.
 
 # Should we use Deboer + 2017 rate for c12(a,g)o16?
 use_c12ag_deboer17  logical   .false.
+
+# The temperature below which we zero out the rates (for simplified-SDC)
+rate_cutoff_temp             real            1.e6
+

--- a/networks/_parameters
+++ b/networks/_parameters
@@ -9,6 +9,3 @@ use_tables  logical   .false.
 # Should we use Deboer + 2017 rate for c12(a,g)o16?
 use_c12ag_deboer17  logical   .false.
 
-# The temperature below which we zero out the rates (for simplified-SDC)
-rate_cutoff_temp             real            1.e6
-

--- a/networks/aprox13/Make.package
+++ b/networks/aprox13/Make.package
@@ -1,8 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp
     CEXE_headers += actual_network.H

--- a/networks/aprox19/Make.package
+++ b/networks/aprox19/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
 
   ifeq ($(USE_CXX_REACTIONS),TRUE)

--- a/networks/aprox21/Make.package
+++ b/networks/aprox21/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
 
   ifeq ($(USE_CXX_REACTIONS),TRUE)

--- a/networks/general_null/Make.package
+++ b/networks/general_null/Make.package
@@ -1,8 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp
     CEXE_headers += actual_network.H

--- a/networks/ignition_chamulak/Make.package
+++ b/networks/ignition_chamulak/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp

--- a/networks/ignition_reaclib/C-burn-simple/Make.package
+++ b/networks/ignition_reaclib/C-burn-simple/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/ignition_reaclib/URCA-simple/Make.package
+++ b/networks/ignition_reaclib/URCA-simple/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/ignition_simple/Make.package
+++ b/networks/ignition_simple/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp

--- a/networks/iso7/Make.package
+++ b/networks/iso7/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp
     CEXE_headers += actual_network.H

--- a/networks/nova/Make.package
+++ b/networks/nova/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/nova2/Make.package
+++ b/networks/nova2/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/powerlaw/Make.package
+++ b/networks/powerlaw/Make.package
@@ -1,5 +1,3 @@
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 CEXE_headers += network_properties.H
 CEXE_headers += actual_network.H
 CEXE_sources += actual_network_data.cpp

--- a/networks/rprox/Make.package
+++ b/networks/rprox/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp
     CEXE_headers += actual_network.H

--- a/networks/sn160/Make.package
+++ b/networks/sn160/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/subch/Make.package
+++ b/networks/subch/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/subch2/Make.package
+++ b/networks/subch2/Make.package
@@ -1,9 +1,6 @@
 CEXE_headers += network_properties.H
 
 ifeq ($(USE_REACT),TRUE)
-
-  DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
   CEXE_sources += actual_network_data.cpp
   CEXE_headers += actual_network.H
   CEXE_headers += actual_rhs.H

--- a/networks/triple_alpha_plus_cago/Make.package
+++ b/networks/triple_alpha_plus_cago/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_sources += actual_network_data.cpp

--- a/networks/vode_example/Make.package
+++ b/networks/vode_example/Make.package
@@ -1,7 +1,5 @@
 CEXE_headers += network_properties.H
 
-DEFINES += -DNETWORK_HAS_CXX_IMPLEMENTATION
-
 ifeq ($(USE_REACT),TRUE)
   ifeq ($(USE_CXX_REACTIONS),TRUE)
     CEXE_headers += actual_network.H


### PR DESCRIPTION
this is used when integrating the system to zero out the rates
if the temperature drops below a certain value.  By default this
is set to -1.0, disabling the cutoff.  In the future, we can have
networks override this as needed, depending on how their rates
are constructed.

This works for both simplified-SDC and Strang.  For simplified SDC,
the advection terms are still included if we fall below the rate threshold.

This PR also removes the old NETWORK_HAS_CXX_IMPLEMENTATION
defines throughout (but leaves a single one in the main make include
for backwards compatibility)