### PR TITLE
Change aion, aion_inv, and zion to have constexpr

### DIFF
--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -28,15 +28,15 @@ constexpr int NumAux = NAUX_NET;
 
 @@PROPERTIES@@
 
-MICROPHYSICS_UNUSED static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
    @@AION@@
   };
 
-MICROPHYSICS_UNUSED static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
+MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
    @@AION_INV@@
   };
 
-MICROPHYSICS_UNUSED static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
    @@ZION@@
   };
 

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -28,15 +28,15 @@ constexpr int NumAux = NAUX_NET;
 
 @@PROPERTIES@@
 
-MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
    @@AION@@
   };
 
-MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
+MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
    @@AION_INV@@
   };
 
-MICROPHYSICS_UNUSED constexpr static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
    @@ZION@@
   };
 

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -15,6 +15,12 @@
 #define MICROPHYSICS_UNUSED
 #endif
 
+#ifdef AMREX_USE_HIP
+#define HIP_CONSTEXPR constexpr
+#else
+#define HIP_CONSTEXPR
+#endif
+
 constexpr int NumSpec = @@NSPEC@@;
 
 #define NUM_EXTRA_SPECIES @@NEXTRASPEC@@
@@ -28,15 +34,15 @@ constexpr int NumAux = NAUX_NET;
 
 @@PROPERTIES@@
 
-MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED HIP_CONSTEXPR static AMREX_GPU_MANAGED amrex::Real aion[NumSpecTotal] = {
    @@AION@@
   };
 
-MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
+MICROPHYSICS_UNUSED HIP_CONSTEXPR static AMREX_GPU_MANAGED amrex::Real aion_inv[NumSpecTotal] = {
    @@AION_INV@@
   };
 
-MICROPHYSICS_UNUSED AMREX_HIP_OR_CUDA_OR_DPCPP(constexpr,,) static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
+MICROPHYSICS_UNUSED HIP_CONSTEXPR static AMREX_GPU_MANAGED amrex::Real zion[NumSpecTotal] = {
    @@ZION@@
   };
 

--- a/rates/aprox_rates.H
+++ b/rates/aprox_rates.H
@@ -299,6 +299,8 @@ void rate_c12c12(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // c12 + c12 reaction
+    // this is the C12(C12,g)Mg24 rate from Caughlin & Fowler (1988)
+
     const Real aa      = 1.0e0_rt + 0.0396_rt*tf.t9;
     Real zz      = 1.0e0_rt/aa;
 
@@ -383,6 +385,8 @@ void rate_o16o16(tf_t tf, const Real den, Real& fr,
                 Real& drrdt) 
 {
     // o16 + o16
+    // this is the O16(O16,g)S32 rate from Caughlin & Fowler (1988)
+
     const Real term  = 7.10e36_rt * tf.t9i23 *
          std::exp(-135.93_rt * tf.t9i13 - 0.629_rt*tf.t923 
          - 0.445_rt*tf.t943 + 0.0103_rt*tf.t9*tf.t9);


### PR DESCRIPTION
This seems to work for `castro/Exec/hydro_tests/Sod` with rocm 5.1.0
Most other places in the code Array1D is used for any quantities accessed inside the kernels, however this would require more intrusive changes to the code which uses these constants.