### PR TITLE
test_rhs only makes sense with jacobian = 1

### DIFF
--- a/unit_test/test_rhs/main.cpp
+++ b/unit_test/test_rhs/main.cpp
@@ -102,6 +102,10 @@ void main_main ()
 
     init_unit_test();
 
+    if (jacobian != 1) {
+        amrex::Error("test_rhs only works for jacobian = 1");
+    }
+
     // C++ EOS initialization (must be done after Fortran eos_init and init_extern_parameters)
     eos_init(small_temp, small_dens);
 


### PR DESCRIPTION
the idea of this test is to directly call the network's RHS functions,
so we only want to test the Jacobian that the network implements