### PR TITLE
powerlaw overrides the default jacobian to 2 -- reset it here

### DIFF
--- a/unit_test/test_rhs/inputs_powerlaw
+++ b/unit_test/test_rhs/inputs_powerlaw
@@ -12,5 +12,4 @@ unit_test.small_temp = 1.e3
 
 unit_test.primary_species_1 = fuel
 
-
-
+integrator.jacobian = 1


### PR DESCRIPTION
for test_rhs, we need the analytic Jacobian, even though it does nothing
here.