### PR TITLE
add the number of steps taken to the burn_t

### DIFF
--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -173,6 +173,7 @@ void actual_integrator (burn_t& state, Real dt)
         state.success = false;
     }
 
+    state.n_step = num_timesteps;
     state.time = t;
 
 #ifndef AMREX_USE_GPU

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -96,6 +96,7 @@ void actual_integrator (burn_t& state, Real dt)
 
     state.n_rhs = vode_state.NFE;
     state.n_jac = vode_state.NJE;
+    state.n_step = vode_state.NST;
 
     // VODE does not always fail even though it can lead to unphysical states.
     // Add some checks that indicate a burn fail even if VODE thinks the

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -100,6 +100,7 @@ void actual_integrator (burn_t& state, Real dt)
 
     state.n_rhs = vode_state.NFE;
     state.n_jac = vode_state.NJE;
+    state.n_step = vode_state.NST;
 
     // Copy the integration data back to the burn state.
     // This will also update the aux state from X if we are using NSE

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -180,7 +180,7 @@ struct burn_t
 #endif
   
   // diagnostics
-  int n_rhs, n_jac;
+  int n_rhs, n_jac, n_step;
 
   // Was the burn successful?
   bool success;

--- a/unit_test/test_react/main.cpp
+++ b/unit_test/test_react/main.cpp
@@ -182,9 +182,9 @@ void main_main ()
         }
     }
 
-    // allocate a multifab for the number of RHS calls
+    // allocate a multifab for the number of RHS calls and steps
     // so we can manually do the reductions (for GPU)
-    iMultiFab integrator_n_rhs(ba, dm, 1, Nghost);
+    iMultiFab integrator_n_rhs(ba, dm, 2, Nghost);
 
     // What time is it now?  We'll use this to compute total react time.
     Real strt_time = ParallelDescriptor::second();
@@ -247,9 +247,14 @@ void main_main ()
     const int IOProc = ParallelDescriptor::IOProcessorNumber();
     ParallelDescriptor::ReduceRealMax(stop_time, IOProc);
 
+    // these operations are over all processors
     int n_rhs_min = integrator_n_rhs.min(0);
     int n_rhs_max = integrator_n_rhs.max(0);
-    long n_rhs_sum = integrator_n_rhs.sum(0, 0, true);
+    long n_rhs_sum = integrator_n_rhs.sum(0);
+
+    int n_step_min = integrator_n_rhs.min(1);
+    int n_step_max = integrator_n_rhs.max(1);
+    long n_step_sum = integrator_n_rhs.sum(1);
 
     // get the name of the integrator from the build info functions
     // written at compile time.  We will append the name of the
@@ -283,6 +288,11 @@ void main_main ()
         std::cout << "min number of rhs calls: " << n_rhs_min << std::endl;
         std::cout << "avg number of rhs calls: " << n_rhs_sum / (n_cell*n_cell*n_cell) << std::endl;
         std::cout << "max number of rhs calls: " << n_rhs_max << std::endl;
+
+        std::cout << "min number of steps: " << n_step_min << std::endl;
+        std::cout << "avg number of steps: " << n_step_sum / (n_cell*n_cell*n_cell) << std::endl;
+        std::cout << "max number of steps: " << n_step_max << std::endl;
+
     }
 
 }

--- a/unit_test/test_react/react_zones.H
+++ b/unit_test/test_react/react_zones.H
@@ -59,6 +59,7 @@ bool do_react (int i, int j, int k, Array4<Real> const& state, Array4<int> const
     state(i, j, k, p.irho_hnuc) = state(i, j, k, p.irho) * burn_state.e / dt;
 
     n_rhs(i, j, k, 0) = burn_state.n_rhs;
+    n_rhs(i, j, k, 1) = burn_state.n_step;
 
     return burn_state.success;
 


### PR DESCRIPTION
this is a better metric than the number of RHS calls when comparing different Jacobians.

test_react now outputs a summary as well.  Note that the sum() we were doing there was local, so it would not have worked with MPI.  This is now fixed.