### PR TITLE
nse indices fix

### DIFF
--- a/nse/nse_index.cpp
+++ b/nse/nse_index.cpp
@@ -3,7 +3,7 @@
 // Declare extern nse index variables
 
 bool NSE_INDEX::initialized;
-AMREX_GPU_MANAGED int NSE_INDEX::p_index;
-AMREX_GPU_MANAGED int NSE_INDEX::h1_index;
-AMREX_GPU_MANAGED int NSE_INDEX::n_index;
-AMREX_GPU_MANAGED int NSE_INDEX::he4_index;
+AMREX_GPU_MANAGED int NSE_INDEX::p_index {-1};
+AMREX_GPU_MANAGED int NSE_INDEX::h1_index {-1};
+AMREX_GPU_MANAGED int NSE_INDEX::n_index {-1};
+AMREX_GPU_MANAGED int NSE_INDEX::he4_index {-1};


### PR DESCRIPTION
To fix the issue where nse indices are initialized to 0, which causes an issue when the network does not have photoionization proton. All indices are now initialized to -1 to prevent this issue.