### PR TITLE
improve and clean up nse solver

### DIFF
--- a/nse/_parameters
+++ b/nse/_parameters
@@ -2,4 +2,5 @@
 
 max_nse_iters    integer    500
 
-use_hybrid_solver    integer   0
+use_hybrid_solver    integer   1
+

--- a/nse/actual_nse.H
+++ b/nse/actual_nse.H
@@ -67,8 +67,8 @@ void init_actual_nse(){
 // struct to store output from constraint equations and jacobian for
 // newton-raphson
 struct Newton_inputs{
-  amrex::Array1D<amrex::Real, 0, 1> eqs;
-  amrex::Array2D<amrex::Real, 0, 1, 0, 1> jac;
+  amrex::Array1D<amrex::Real, 1, 2> eqs;
+  amrex::Array2D<amrex::Real, 1, 2, 1, 2> jac;
 };
 
 template <typename T>
@@ -165,7 +165,7 @@ Newton_inputs nse_constraint(const T& state){
 
     // Now find constraint equations
 
-    nse_inputs.eqs(0) = -1.0_rt;
+    nse_inputs.eqs(1) = -1.0_rt;
 
     for (int n = 0; n < NumSpec; ++n){
         if (n == NSE_INDEX::p_index){
@@ -174,29 +174,29 @@ Newton_inputs nse_constraint(const T& state){
 
         // constraint equation 1, mass fraction sum to 1
 
-        nse_inputs.eqs(0) += nse_state.xn[n];
+        nse_inputs.eqs(1) += nse_state.xn[n];
     }
 
     // constraint equation 2, electron fraction should be the same
 
-    nse_inputs.eqs(1) = nse_state.y_e - state.y_e;
+    nse_inputs.eqs(2) = nse_state.y_e - state.y_e;
     
     // evaluate jacobian of the constraint
 
-    nse_inputs.jac(0,0) = 0.0_rt;
-    nse_inputs.jac(0,1) = 0.0_rt;
-    nse_inputs.jac(1,0) = 0.0_rt;
     nse_inputs.jac(1,1) = 0.0_rt;
+    nse_inputs.jac(1,2) = 0.0_rt;
+    nse_inputs.jac(2,1) = 0.0_rt;
+    nse_inputs.jac(2,2) = 0.0_rt;
 
     for (int n = 0; n < NumSpec; ++n){
         if (n == NSE_INDEX::p_index){
             continue;
         }
 
-        nse_inputs.jac(0,0) += nse_state.xn[n] * zion[n] / C::k_B / state.T * C::Legacy::MeV2erg ;
-        nse_inputs.jac(0,1) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / state.T * C::Legacy::MeV2erg;
-        nse_inputs.jac(1,0) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
-        nse_inputs.jac(1,1) += nse_state.xn[n] * zion[n] * (aion[n] - zion[n]) * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
+        nse_inputs.jac(1, 1) += nse_state.xn[n] * zion[n] / C::k_B / state.T * C::Legacy::MeV2erg ;
+        nse_inputs.jac(1, 2) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / state.T * C::Legacy::MeV2erg;
+        nse_inputs.jac(2, 1) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
+        nse_inputs.jac(2, 2) += nse_state.xn[n] * zion[n] * (aion[n] - zion[n]) * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
     }
 
     return nse_inputs;
@@ -317,7 +317,7 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
     }
 
     // Find the max of the jacobian used for scaling determinant to prevent digit overflow
-    auto scale_fac = amrex::max(f.jac(1,1),amrex::max(f.jac(1,0), amrex::max(f.jac(0,0), f.jac(0,1))));
+    auto scale_fac = amrex::max(f.jac(2,2),amrex::max(f.jac(2,1), amrex::max(f.jac(1,1), f.jac(1,2))));
 
     // if jacobians are small, then no need for scaling
     if (scale_fac < 1.0e150){
@@ -325,7 +325,7 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
     }
 
     // Specific inverse 2x2 matrix, perhaps can write a function for solving n systems of equations.
-    det = f.jac(0, 0) / scale_fac * f.jac(1, 1) - f.jac(0, 1) / scale_fac * f.jac(1, 0);
+    det = f.jac(1, 1) / scale_fac * f.jac(2, 2) - f.jac(1, 2) / scale_fac * f.jac(2, 1);
 
     // check if determinant is 0
     if (det == 0.0_rt){
@@ -333,14 +333,14 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
     }
 
     // find inverse jacobian
-    inverse_jac(0, 0) = f.jac(1,1) / scale_fac / det;
-    inverse_jac(0, 1) = -f.jac(0,1) / scale_fac / det;
-    inverse_jac(1, 0) = -f.jac(1,0) / scale_fac / det;
-    inverse_jac(1, 1) = f.jac(0,0) / scale_fac / det;
+    inverse_jac(1, 1) = f.jac(2, 2) / scale_fac / det;
+    inverse_jac(1, 2) = -f.jac(1, 2) / scale_fac / det;
+    inverse_jac(2, 1) = -f.jac(2, 1) / scale_fac / det;
+    inverse_jac(2, 2) = f.jac(1, 1) / scale_fac / det;
 
     // find the difference
-    d_mu_p = -(f.eqs(0) * inverse_jac(0,0) + f.eqs(1) * inverse_jac(0,1));
-    d_mu_n = -(f.eqs(0) * inverse_jac(1,0) + f.eqs(1) * inverse_jac(1,1));
+    d_mu_p = -(f.eqs(1) * inverse_jac(1, 1) + f.eqs(2) * inverse_jac(1, 2));
+    d_mu_n = -(f.eqs(1) * inverse_jac(2, 1) + f.eqs(2) * inverse_jac(2, 2));
 
     // if diff goes beyond 1.0e3_rt, likely that its not making good progress..
     if (std::abs(d_mu_p) > 1.0e3_rt or std::abs(d_mu_n) > 1.0e3_rt){
@@ -391,20 +391,71 @@ T get_actual_nse_state(T& state, amrex::Real eps=1.0e-4_rt, bool input_ye_is_val
     composition(state);
   }
 
+  // amrex::Array1D<amrex::Real, 1, 2> init_x;
+  // init_x(1) = state.mu_p;
+  // init_x(2) = state.mu_n;
+  
+  // amrex::Real dx;
+  // bool is_pos_new;
+  // bool is_pos_old = false;
+  
   // invoke newton-raphson to solve chemical potential of proton and neutron
   if (use_hybrid_solver) {
-      nse_hybrid_solver(state, eps);
-  } else {
-      nse_nr_solver(state, eps);
+    // for (int i = 0; i < 20; ++i){
+
+    //   dx = 0.5_rt;
+    //   state.mu_p = init_x(1);
+    //   state.mu_n = init_x(2);
+
+    //   // std::cout << "state mu_p in outer " << state.mu_p << std::endl;
+    //   // std::cout << "state mu_n in outer " << state.mu_n << std::endl;
+      
+    //   for (int j = 0; j < 20; ++j){
+    nse_hybrid_solver(state, eps);
+	
+    // 	Newton_inputs f = nse_constraint(state);
+    // 	if (std::abs(f.eqs(1)) < 1.0e-3_rt || std::abs(f.eqs(2)) < 1.0e-3_rt){
+    // 	  auto nse_state = get_nse_state(state);
+    // 	  return nse_state;
+    // 	}
+    // 	std::cout << "f.eq 1 " << f.eqs(1) << std::endl;
+    // 	std::cout << "f.eq 2 " << f.eqs(2) << std::endl;
+    // 	if (f.eqs(1) > 0.0_rt && f.eqs(2) > 0.0_rt){
+    // 	  is_pos_new = true;
+    // 	}
+    // 	else{
+    // 	  is_pos_new = false;
+    // 	}
+
+    // 	if (is_pos_old != is_pos_new){
+    // 	  dx *= 0.8_rt;
+    // 	}
+
+    // 	if (is_pos_new){
+    // 	  state.mu_p -= dx;
+    // 	  state.mu_n -= dx;
+    // 	}
+    // 	else{
+    // 	  state.mu_p += dx;
+    // 	  state.mu_n += dx;
+    // 	}
+      
+    // 	is_pos_old = is_pos_new;
+    //   }
+    //   init_x(1) -= 0.5_rt;
+    // }
   }
+  else{
+    nse_nr_solver(state, eps);
+  }
+
   
-  Newton_inputs f = nse_constraint(state);
 
   // extra check for convergence since hybrj has a bug in its convergence check
-
-  if (std::abs(f.eqs(0)) > 1.0e-3_rt || std::abs(f.eqs(1)) > 1.0e-3_rt){
-    amrex::Error("failed to solve!");
-  }
+  // Newton_inputs f = nse_constraint(state);  
+  // if (std::abs(f.eqs(1)) > 1.0e-3_rt || std::abs(f.eqs(2)) > 1.0e-3_rt){
+  //   amrex::Error("failed to solve!");
+  // }
 
   // get the nse_state
 

--- a/nse/actual_nse.H
+++ b/nse/actual_nse.H
@@ -14,6 +14,7 @@
 #include <nse_index.H>
 #include <hybrj.H>
 
+
 // Initialization for nse, check whether network is valid and stores indices
 
 void init_actual_nse(){
@@ -43,7 +44,7 @@ void init_actual_nse(){
 
   // Check if network results in singular jacobian first, require at
   // least one nuclei that nuclei.Z != nuclei.N.  Some examples include
-  // aprox13 and iso7
+  // aprox13 and iso7. If use hybrj solver, this is no longer an issue.
   if (!use_hybrid_solver){
     bool singular_network = true;
     for (int n = 0; n < NumSpec; ++n){
@@ -85,10 +86,16 @@ T get_nse_state(const T& state)
   amrex::Real gamma;
   amrex::Real u_c;
 
-  // Need partition function, set it to 1 for now.
+  // set partition function and spin
+  
+  amrex::Real pf = 1.0_rt;
+  amrex::Real dpf_dT;
+  amrex::Real spin = 1.0_rt;
 
-  amrex::Real partition_function = 1.0_rt;
-
+#ifdef TFACTORS_H
+  auto tfactors = evaluate_tfactors(temperature);
+#endif
+  
   for (int n = 0; n < NumSpec; ++n){
       if (n == NSE_INDEX::p_index){
           continue;
@@ -108,7 +115,13 @@ T get_nse_state(const T& state)
                                std::sqrt(1.0_rt + gamma / A2))) +
            2.0_rt * A3 * (std::sqrt(gamma) - std::atan(std::sqrt(gamma))));
 
-
+      // fill partition function and get spin
+      
+#ifdef PARTITION_FUNCTIONS_H      
+      spin = get_spin_state(n+1);
+      get_partition_function(n+1, tfactors, pf, dpf_dT);
+#endif
+      
       // find nse mass frac
 
       // prevent an overflow on exp by capping the exponent -- we hope that a subsequent
@@ -119,7 +132,7 @@ T get_nse_state(const T& state)
                                   - u_c + network::bion(n+1)) /
                                  C::k_B / state.T * C::Legacy::MeV2erg);
 
-      nse_state.xn[n] = network::mion(n+1) * partition_function / state.rho *
+      nse_state.xn[n] = network::mion(n+1) * pf * spin / state.rho *
           std::pow(2.0 * M_PI * network::mion(n+1) *
                    C::k_B * state.T / std::pow(C::hplanck, 2.0_rt), 3.0_rt/2.0_rt) *
           std::exp(exponent);
@@ -198,7 +211,7 @@ void jcn_hybrid(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
         if (n == NSE_INDEX::p_index){
             continue;
         }
-
+	
         fjac(1, 1) += nse_state.xn[n] * zion[n] / C::k_B / state.T * C::Legacy::MeV2erg ;
         fjac(1, 2) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / state.T * C::Legacy::MeV2erg;
         fjac(2, 1) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;

--- a/nse/actual_nse.H
+++ b/nse/actual_nse.H
@@ -64,13 +64,6 @@ void init_actual_nse(){
 }
 
 
-// struct to store output from constraint equations and jacobian for
-// newton-raphson
-struct Newton_inputs{
-  amrex::Array1D<amrex::Real, 1, 2> eqs;
-  amrex::Array2D<amrex::Real, 1, 2, 1, 2> jac;
-};
-
 template <typename T>
 T get_nse_state(const T& state)
 {
@@ -121,7 +114,7 @@ T get_nse_state(const T& state)
       // prevent an overflow on exp by capping the exponent -- we hope that a subsequent
       // iteration will make it happy again
 
-      Real exponent = amrex::min(700.0_rt,
+      Real exponent = amrex::min(500.0_rt,
                                  (zion[n] * state.mu_p + (aion[n] - zion[n]) * state.mu_n
                                   - u_c + network::bion(n+1)) /
                                  C::k_B / state.T * C::Legacy::MeV2erg);
@@ -151,59 +144,8 @@ T get_nse_state(const T& state)
 }
 
 
-template <typename T>
-Newton_inputs nse_constraint(const T& state){
-    // This functions finds the constraint equations and jacobian used
-    // for calculating nse.
 
-    Newton_inputs nse_inputs;
-
-    // calculate the nse state based on initial conditions of mu_p and
-    // mu_n which are chemical potential of proton and neutron
-
-    auto nse_state = get_nse_state(state);
-
-    // Now find constraint equations
-
-    nse_inputs.eqs(1) = -1.0_rt;
-
-    for (int n = 0; n < NumSpec; ++n){
-        if (n == NSE_INDEX::p_index){
-            continue;
-        }
-
-        // constraint equation 1, mass fraction sum to 1
-
-        nse_inputs.eqs(1) += nse_state.xn[n];
-    }
-
-    // constraint equation 2, electron fraction should be the same
-
-    nse_inputs.eqs(2) = nse_state.y_e - state.y_e;
-    
-    // evaluate jacobian of the constraint
-
-    nse_inputs.jac(1,1) = 0.0_rt;
-    nse_inputs.jac(1,2) = 0.0_rt;
-    nse_inputs.jac(2,1) = 0.0_rt;
-    nse_inputs.jac(2,2) = 0.0_rt;
-
-    for (int n = 0; n < NumSpec; ++n){
-        if (n == NSE_INDEX::p_index){
-            continue;
-        }
-
-        nse_inputs.jac(1, 1) += nse_state.xn[n] * zion[n] / C::k_B / state.T * C::Legacy::MeV2erg ;
-        nse_inputs.jac(1, 2) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / state.T * C::Legacy::MeV2erg;
-        nse_inputs.jac(2, 1) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
-        nse_inputs.jac(2, 2) += nse_state.xn[n] * zion[n] * (aion[n] - zion[n]) * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
-    }
-
-    return nse_inputs;
-}
-
-
-// for the hybrid Powell solver
+// constraint equation
 
 template<typename T>
 void fcn_hybrid(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
@@ -232,6 +174,8 @@ void fcn_hybrid(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
     fvec(2) = nse_state.y_e - state.y_e;
 
 }
+
+// constraint jacobian
 
 template<typename T>
 void jcn_hybrid(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
@@ -354,12 +298,11 @@ void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-10_rt) {
 
 // A newton-raphson solver for finding nse state used for calibrating
 // chemical potential of proton and neutron
+
 template<typename T>
 void nse_nr_solver(T& state, amrex::Real eps=1.0e-10_rt) {
 
   bool converged = false;                                     // whether nse solver converged or not
-
-  // Newton_inputs f = nse_constraint(state);                    // get constraint eqs and jacobian
 
   amrex::Array1D<amrex::Real, 1, 2> f;
   amrex::Array2D<amrex::Real, 1, 2, 1, 2> jac;
@@ -380,9 +323,8 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-10_rt) {
   // begin newton-raphson
   for (int i = 0; i < max_nse_iters; ++i){
 
-    std::cout << "d_mup " << d_mu_p << std::endl;
-    std::cout << "d_mu_n " << d_mu_n << std::endl;
     // check if current state fulfills constraint equation
+
     if (std::abs(d_mu_p) < eps * std::abs(x(1)) &&
         std::abs(d_mu_n) < eps * std::abs(x(2))){
       converged = true;
@@ -392,28 +334,26 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-10_rt) {
     }
 
     // Find the max of the jacobian used for scaling determinant to prevent digit overflow
-    //auto scale_fac = amrex::max(f.jac(2,2),amrex::max(f.jac(2,1), amrex::max(f.jac(1,1), f.jac(1,2))));
     
     auto scale_fac = amrex::max(jac(2,2), amrex::max(jac(2,1), amrex::max(jac(1,1), jac(1,2))));
     
     // if jacobians are small, then no need for scaling
+
     if (scale_fac < 1.0e150){
       scale_fac = 1.0_rt;
     }
 
     // Specific inverse 2x2 matrix, perhaps can write a function for solving n systems of equations.
+
     det = jac(1, 1) / scale_fac * jac(2, 2) - jac(1, 2) / scale_fac * jac(2, 1);
 
     // check if determinant is 0
+    
     if (det == 0.0_rt){
       amrex::Error("Jacobian is a singular matrix! Try a different initial guess!");
     }
 
     // find inverse jacobian
-    // inverse_jac(1, 1) = f.jac(2, 2) / scale_fac / det;
-    // inverse_jac(1, 2) = -f.jac(1, 2) / scale_fac / det;
-    // inverse_jac(2, 1) = -f.jac(2, 1) / scale_fac / det;
-    // inverse_jac(2, 2) = f.jac(1, 1) / scale_fac / det;
 
     inverse_jac(1, 1) = jac(2, 2) / scale_fac / det;
     inverse_jac(1, 2) = -jac(1, 2) / scale_fac / det;
@@ -421,32 +361,29 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-10_rt) {
     inverse_jac(2, 2) = jac(1, 1) / scale_fac / det;
     
     // find the difference
-    // d_mu_p = -(f.eqs(1) * inverse_jac(1, 1) + f.eqs(2) * inverse_jac(1, 2));
-    // d_mu_n = -(f.eqs(1) * inverse_jac(2, 1) + f.eqs(2) * inverse_jac(2, 2));
 
     d_mu_p = -(f(1) * inverse_jac(1, 1) + f(2) * inverse_jac(1, 2));
     d_mu_n = -(f(1) * inverse_jac(2, 1) + f(2) * inverse_jac(2, 2));
     
     // if diff goes beyond 1.0e3_rt, likely that its not making good progress..
+
     if (std::abs(d_mu_p) > 1.0e3_rt || std::abs(d_mu_n) > 1.0e3_rt){
       amrex::Error("Not making good progress, breaking");
     }
 
     // update new solution
-    // state.mu_p += d_mu_p;
-    // state.mu_n += d_mu_n;
 
     x(1) += d_mu_p;
     x(2) += d_mu_n;
     
     // check whether solution results in nan
-    // if (std::isnan(state.mu_p) or std::isnan(state.mu_n)){
+
     if (std::isnan(x(1)) || std::isnan(x(2))){
 	amrex::Error("Nan encountered, likely due to overflow in digits or not making good progress");
       }
 
     // update constraint
-    // f = nse_constraint(state);
+
     jcn_hybrid(x, jac, state, flag);
     fcn_hybrid(x, f, state, flag);
   }

--- a/nse/actual_nse.H
+++ b/nse/actual_nse.H
@@ -41,25 +41,25 @@ void init_actual_nse(){
     }
   }
 
-
   // Check if network results in singular jacobian first, require at
   // least one nuclei that nuclei.Z != nuclei.N.  Some examples include
   // aprox13 and iso7
-
-  bool singular_network = true;
-  for (int n = 0; n < NumSpec; ++n){
-    if (n == NSE_INDEX::p_index){
-      continue;
+  if (!use_hybrid_solver){
+    bool singular_network = true;
+    for (int n = 0; n < NumSpec; ++n){
+      if (n == NSE_INDEX::p_index){
+	continue;
+      }
+      if (zion[n] != aion[n] - zion[n]){
+	singular_network = false;
+      }
     }
-    if (zion[n] != aion[n] - zion[n]){
-      singular_network = false;
+    
+    if (singular_network == true){
+      amrex::Error("This network always results in singular jacobian matrix, thus can't find nse mass fraction using nr!");
     }
   }
-
-  if (singular_network == true){
-    amrex::Error("This network always results in singular jacobian matrix, thus can't find nse mass fraction!");
-  }
-
+  
   NSE_INDEX::initialized = true;
 }
 
@@ -121,7 +121,7 @@ T get_nse_state(const T& state)
       // prevent an overflow on exp by capping the exponent -- we hope that a subsequent
       // iteration will make it happy again
 
-      Real exponent = amrex::min(500.0_rt,
+      Real exponent = amrex::min(700.0_rt,
                                  (zion[n] * state.mu_p + (aion[n] - zion[n]) * state.mu_n
                                   - u_c + network::bion(n+1)) /
                                  C::k_B / state.T * C::Legacy::MeV2erg);
@@ -229,7 +229,7 @@ void fcn_hybrid(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
 
     // constraint equation 2, electron fraction should be the same
 
-    fvec(2) =  nse_state.y_e - state.y_e;
+    fvec(2) = nse_state.y_e - state.y_e;
 
 }
 
@@ -264,68 +264,145 @@ void jcn_hybrid(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
 }
 
 template<typename T>
-void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-4_rt) {
+void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-10_rt) {
 
     hybrj_t<2> hj;
 
     // we'll take x[1] = mu_p, x[2] = mu_n
-
-    hj.x(1) = state.mu_p;
-    hj.x(2) = state.mu_n;
-
+    
     hj.xtol = eps;
-    hj.mode = 2;
+    hj.mode = 1;
 
-    for (int j = 1; j <= 2; ++j) {
-        hj.diag(j) = 1.0_rt;
+    // random flag number for evaluation in for loop;
+
+    int flag = 0;
+    
+    // Fine-tune variables
+    
+    amrex::Real dx;
+    bool is_pos_new;
+    bool is_pos_old = false;
+    
+    amrex::Array1D<amrex::Real, 1, 2> f;
+    amrex::Array1D<amrex::Real, 1, 2> outer_x;
+    amrex::Array1D<amrex::Real, 1, 2> inner_x;
+
+    outer_x(1) = state.mu_p;
+    outer_x(2) = state.mu_n;
+
+    // for (int j = 1; j <= 2; ++j) {
+    //     hj.diag(j) = 1.0_rt;
+    // }
+
+    // fine tuning initial guesses
+    
+    for (int i = 0; i < 20; ++i){
+
+      dx = 0.5_rt;
+      inner_x(1) = outer_x(1);
+      inner_x(2) = outer_x(2);
+
+      for (int j = 0; j < 20; ++j){
+
+	hj.x(1) = inner_x(1);
+	hj.x(2) = inner_x(2);
+	
+	hybrj(hj, state, fcn_hybrid<T>, jcn_hybrid<T>);
+    
+	fcn_hybrid(hj.x, f, state, flag);
+
+	if (std::abs(f(1)) < eps && std::abs(f(2)) < eps){
+
+	  state.mu_p = hj.x(1);
+	  state.mu_n = hj.x(2);
+	  return;
+	}
+
+	if (f(1) > 0.0_rt && f(2) > 0.0_rt){
+	  is_pos_new = true;
+	}
+	else{
+	  is_pos_new = false;
+	}
+
+	if (is_pos_old != is_pos_new){
+	  dx *= 0.8_rt;
+	}
+
+	if (is_pos_new){
+	  inner_x(1) -= dx;
+	  inner_x(2) -= dx;
+	}
+	else{
+	  inner_x(1) += dx;
+	  inner_x(2) += dx;
+	}
+      
+	is_pos_old = is_pos_new;
+      }
+      
+      outer_x(1) -= 0.5_rt;
+      
     }
-
-    hybrj(hj, state, fcn_hybrid<T>, jcn_hybrid<T>);
-
-    if (hj.info != 1) {
-        amrex::Error("failed to solve");
-    }
-
-    state.mu_p = hj.x(1);
-    state.mu_n = hj.x(2);
-
+    
+    // if (hj.info != 1) {
+    //     amrex::Error("failed to solve");
+    // }
+    
+    amrex::Error("failed to solve");
 }
 
 // A newton-raphson solver for finding nse state used for calibrating
 // chemical potential of proton and neutron
 template<typename T>
-void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
+void nse_nr_solver(T& state, amrex::Real eps=1.0e-10_rt) {
 
   bool converged = false;                                     // whether nse solver converged or not
 
-  Newton_inputs f = nse_constraint(state);                    // get constraint eqs and jacobian
+  // Newton_inputs f = nse_constraint(state);                    // get constraint eqs and jacobian
 
+  amrex::Array1D<amrex::Real, 1, 2> f;
+  amrex::Array2D<amrex::Real, 1, 2, 1, 2> jac;
+  amrex::Array1D<amrex::Real, 1, 2> x;
+  int flag = 0;
+
+  x(1) = state.mu_p;
+  x(2) = state.mu_n;
+
+  jcn_hybrid(x, jac, state, flag);
+  fcn_hybrid(x, f, state,flag);
+    
   amrex::Real det;                                            // store determinant for finding inverse jac
-  decltype(f.jac) inverse_jac;                                // store inverse jacobian
-  amrex::Real d_mu_p = std::numeric_limits<Real>::max();                                // difference in chemical potential of proton
-  amrex::Real d_mu_n = std::numeric_limits<Real>::max();                                // difference in chemical potential of neutron
+  amrex::Array2D<amrex::Real, 1, 2, 1, 2> inverse_jac;        // store inverse jacobian
+  amrex::Real d_mu_p = std::numeric_limits<Real>::max();      // difference in chemical potential of proton
+  amrex::Real d_mu_n = std::numeric_limits<Real>::max();      // difference in chemical potential of neutron
 
   // begin newton-raphson
   for (int i = 0; i < max_nse_iters; ++i){
 
+    std::cout << "d_mup " << d_mu_p << std::endl;
+    std::cout << "d_mu_n " << d_mu_n << std::endl;
     // check if current state fulfills constraint equation
-//    if (std::abs(f.eqs(0)) < eps && std::abs(f.eqs(1)) < eps){
-    if (std::abs(d_mu_p) < eps * std::abs(state.mu_p) &&
-        std::abs(d_mu_n) < eps * std::abs(state.mu_n)){
+    if (std::abs(d_mu_p) < eps * std::abs(x(1)) &&
+        std::abs(d_mu_n) < eps * std::abs(x(2))){
       converged = true;
+      state.mu_p = x(1);
+      state.mu_n = x(2);
       break;
     }
 
     // Find the max of the jacobian used for scaling determinant to prevent digit overflow
-    auto scale_fac = amrex::max(f.jac(2,2),amrex::max(f.jac(2,1), amrex::max(f.jac(1,1), f.jac(1,2))));
-
+    //auto scale_fac = amrex::max(f.jac(2,2),amrex::max(f.jac(2,1), amrex::max(f.jac(1,1), f.jac(1,2))));
+    
+    auto scale_fac = amrex::max(jac(2,2), amrex::max(jac(2,1), amrex::max(jac(1,1), jac(1,2))));
+    
     // if jacobians are small, then no need for scaling
     if (scale_fac < 1.0e150){
       scale_fac = 1.0_rt;
     }
 
     // Specific inverse 2x2 matrix, perhaps can write a function for solving n systems of equations.
-    det = f.jac(1, 1) / scale_fac * f.jac(2, 2) - f.jac(1, 2) / scale_fac * f.jac(2, 1);
+    det = jac(1, 1) / scale_fac * jac(2, 2) - jac(1, 2) / scale_fac * jac(2, 1);
 
     // check if determinant is 0
     if (det == 0.0_rt){
@@ -333,31 +410,45 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
     }
 
     // find inverse jacobian
-    inverse_jac(1, 1) = f.jac(2, 2) / scale_fac / det;
-    inverse_jac(1, 2) = -f.jac(1, 2) / scale_fac / det;
-    inverse_jac(2, 1) = -f.jac(2, 1) / scale_fac / det;
-    inverse_jac(2, 2) = f.jac(1, 1) / scale_fac / det;
+    // inverse_jac(1, 1) = f.jac(2, 2) / scale_fac / det;
+    // inverse_jac(1, 2) = -f.jac(1, 2) / scale_fac / det;
+    // inverse_jac(2, 1) = -f.jac(2, 1) / scale_fac / det;
+    // inverse_jac(2, 2) = f.jac(1, 1) / scale_fac / det;
 
+    inverse_jac(1, 1) = jac(2, 2) / scale_fac / det;
+    inverse_jac(1, 2) = -jac(1, 2) / scale_fac / det;
+    inverse_jac(2, 1) = -jac(2, 1) / scale_fac / det;
+    inverse_jac(2, 2) = jac(1, 1) / scale_fac / det;
+    
     // find the difference
-    d_mu_p = -(f.eqs(1) * inverse_jac(1, 1) + f.eqs(2) * inverse_jac(1, 2));
-    d_mu_n = -(f.eqs(1) * inverse_jac(2, 1) + f.eqs(2) * inverse_jac(2, 2));
+    // d_mu_p = -(f.eqs(1) * inverse_jac(1, 1) + f.eqs(2) * inverse_jac(1, 2));
+    // d_mu_n = -(f.eqs(1) * inverse_jac(2, 1) + f.eqs(2) * inverse_jac(2, 2));
 
+    d_mu_p = -(f(1) * inverse_jac(1, 1) + f(2) * inverse_jac(1, 2));
+    d_mu_n = -(f(1) * inverse_jac(2, 1) + f(2) * inverse_jac(2, 2));
+    
     // if diff goes beyond 1.0e3_rt, likely that its not making good progress..
-    if (std::abs(d_mu_p) > 1.0e3_rt or std::abs(d_mu_n) > 1.0e3_rt){
+    if (std::abs(d_mu_p) > 1.0e3_rt || std::abs(d_mu_n) > 1.0e3_rt){
       amrex::Error("Not making good progress, breaking");
     }
 
     // update new solution
-    state.mu_p += d_mu_p;
-    state.mu_n += d_mu_n;
+    // state.mu_p += d_mu_p;
+    // state.mu_n += d_mu_n;
 
+    x(1) += d_mu_p;
+    x(2) += d_mu_n;
+    
     // check whether solution results in nan
-    if (std::isnan(state.mu_p) or std::isnan(state.mu_n)){
-      amrex::Error("Nan encountered, likely due to overflow in digits or not making good progress");
-    }
+    // if (std::isnan(state.mu_p) or std::isnan(state.mu_n)){
+    if (std::isnan(x(1)) || std::isnan(x(2))){
+	amrex::Error("Nan encountered, likely due to overflow in digits or not making good progress");
+      }
 
     // update constraint
-    f = nse_constraint(state);
+    // f = nse_constraint(state);
+    jcn_hybrid(x, jac, state, flag);
+    fcn_hybrid(x, f, state, flag);
   }
 
   if (!converged){
@@ -367,7 +458,7 @@ void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
 
 // Get the NSE state;
 template<typename T>
-T get_actual_nse_state(T& state, amrex::Real eps=1.0e-4_rt, bool input_ye_is_valid=false){
+T get_actual_nse_state(T& state, amrex::Real eps=1.0e-10_rt, bool input_ye_is_valid=false){
 
   // Check whether initialized or not
   if (!NSE_INDEX::initialized){
@@ -391,74 +482,14 @@ T get_actual_nse_state(T& state, amrex::Real eps=1.0e-4_rt, bool input_ye_is_val
     composition(state);
   }
 
-  // amrex::Array1D<amrex::Real, 1, 2> init_x;
-  // init_x(1) = state.mu_p;
-  // init_x(2) = state.mu_n;
-  
-  // amrex::Real dx;
-  // bool is_pos_new;
-  // bool is_pos_old = false;
-  
   // invoke newton-raphson to solve chemical potential of proton and neutron
   if (use_hybrid_solver) {
-    // for (int i = 0; i < 20; ++i){
-
-    //   dx = 0.5_rt;
-    //   state.mu_p = init_x(1);
-    //   state.mu_n = init_x(2);
-
-    //   // std::cout << "state mu_p in outer " << state.mu_p << std::endl;
-    //   // std::cout << "state mu_n in outer " << state.mu_n << std::endl;
-      
-    //   for (int j = 0; j < 20; ++j){
     nse_hybrid_solver(state, eps);
-	
-    // 	Newton_inputs f = nse_constraint(state);
-    // 	if (std::abs(f.eqs(1)) < 1.0e-3_rt || std::abs(f.eqs(2)) < 1.0e-3_rt){
-    // 	  auto nse_state = get_nse_state(state);
-    // 	  return nse_state;
-    // 	}
-    // 	std::cout << "f.eq 1 " << f.eqs(1) << std::endl;
-    // 	std::cout << "f.eq 2 " << f.eqs(2) << std::endl;
-    // 	if (f.eqs(1) > 0.0_rt && f.eqs(2) > 0.0_rt){
-    // 	  is_pos_new = true;
-    // 	}
-    // 	else{
-    // 	  is_pos_new = false;
-    // 	}
-
-    // 	if (is_pos_old != is_pos_new){
-    // 	  dx *= 0.8_rt;
-    // 	}
-
-    // 	if (is_pos_new){
-    // 	  state.mu_p -= dx;
-    // 	  state.mu_n -= dx;
-    // 	}
-    // 	else{
-    // 	  state.mu_p += dx;
-    // 	  state.mu_n += dx;
-    // 	}
-      
-    // 	is_pos_old = is_pos_new;
-    //   }
-    //   init_x(1) -= 0.5_rt;
-    // }
   }
   else{
     nse_nr_solver(state, eps);
   }
-
   
-
-  // extra check for convergence since hybrj has a bug in its convergence check
-  // Newton_inputs f = nse_constraint(state);  
-  // if (std::abs(f.eqs(1)) > 1.0e-3_rt || std::abs(f.eqs(2)) > 1.0e-3_rt){
-  //   amrex::Error("failed to solve!");
-  // }
-
-  // get the nse_state
-
   auto nse_state = get_nse_state(state);
   
   return nse_state;

--- a/nse/actual_nse.H
+++ b/nse/actual_nse.H
@@ -132,11 +132,22 @@ T get_nse_state(const T& state)
           std::exp(exponent);
   }
 
+  nse_state.y_e = 0.0_rt;
+
+  for (int n = 0; n < NumSpec; ++n){
+    if (n == NSE_INDEX::p_index){
+      continue;
+    }
+    
+    // constraint equation 1, mass fraction sum to 1
+    
+    nse_state.y_e += nse_state.xn[n] * zion[n] * aion_inv[n];
+  }
+  
   nse_state.T = state.T;
   nse_state.rho = state.rho;
 
   return nse_state;
-
 }
 
 
@@ -154,8 +165,6 @@ Newton_inputs nse_constraint(const T& state){
 
     // Now find constraint equations
 
-    nse_state.y_e = 0.0_rt;
-
     nse_inputs.eqs(0) = -1.0_rt;
 
     for (int n = 0; n < NumSpec; ++n){
@@ -166,13 +175,12 @@ Newton_inputs nse_constraint(const T& state){
         // constraint equation 1, mass fraction sum to 1
 
         nse_inputs.eqs(0) += nse_state.xn[n];
-        nse_state.y_e += nse_state.xn[n] * zion[n] * aion_inv[n];
     }
 
     // constraint equation 2, electron fraction should be the same
 
     nse_inputs.eqs(1) = nse_state.y_e - state.y_e;
-
+    
     // evaluate jacobian of the constraint
 
     nse_inputs.jac(0,0) = 0.0_rt;
@@ -207,8 +215,6 @@ void fcn_hybrid(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
 
     auto nse_state = get_nse_state(current_state);
 
-    nse_state.y_e = 0.0_rt;
-
     fvec(1) = -1.0_rt;
 
     for (int n = 0; n < NumSpec; ++n){
@@ -219,7 +225,6 @@ void fcn_hybrid(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
         // constraint equation 1, mass fraction sum to 1
 
         fvec(1) += nse_state.xn[n];
-        nse_state.y_e += nse_state.xn[n] * zion[n] * aion_inv[n];
     }
 
     // constraint equation 2, electron fraction should be the same
@@ -259,7 +264,7 @@ void jcn_hybrid(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
 }
 
 template<typename T>
-void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-3_rt) {
+void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-4_rt) {
 
     hybrj_t<2> hj;
 
@@ -289,7 +294,7 @@ void nse_hybrid_solver(T& state, amrex::Real eps=1.0e-3_rt) {
 // A newton-raphson solver for finding nse state used for calibrating
 // chemical potential of proton and neutron
 template<typename T>
-void nse_nr_solver(T& state, amrex::Real eps=1.0e-3_rt) {
+void nse_nr_solver(T& state, amrex::Real eps=1.0e-4_rt) {
 
   bool converged = false;                                     // whether nse solver converged or not
 
@@ -392,9 +397,19 @@ T get_actual_nse_state(T& state, amrex::Real eps=1.0e-4_rt, bool input_ye_is_val
   } else {
       nse_nr_solver(state, eps);
   }
+  
+  Newton_inputs f = nse_constraint(state);
+
+  // extra check for convergence since hybrj has a bug in its convergence check
+
+  if (std::abs(f.eqs(0)) > 1.0e-3_rt || std::abs(f.eqs(1)) > 1.0e-3_rt){
+    amrex::Error("failed to solve!");
+  }
 
   // get the nse_state
-  T nse_state = get_nse_state(state);
+
+  auto nse_state = get_nse_state(state);
+  
   return nse_state;
 }
 

--- a/nse/make_table/burn_cell.H
+++ b/nse/make_table/burn_cell.H
@@ -29,52 +29,69 @@ void burn_cell_c()
                 state.rho = rho;
                 state.y_e = Ye;
 
+		if (state.y_e > 0.52_rt){
+		  state.mu_p = -2.0_rt;
+		  state.mu_n = -15.0_rt;
+		}
+		else if (state.y_e > 0.48_rt){
+		  state.mu_p = -7.0_rt;
+		  state.mu_n = -11.0_rt;
+		}
+		else if (state.y_e > 0.4_rt){
+		  state.mu_p = -10.0_rt;
+		  state.mu_n = -8.0_rt;
+		}
+		else{
+		  state.mu_p = -16.0;
+		  state.mu_n = -3.0;
+		}
+		
                 // initial guess
 
-                if (state.T >= 4.5e9_rt) {
+                // if (state.T >= 4.5e9_rt) {
 
-                    if (state.y_e < 0.45_rt) {
-                        state.mu_p = -15.0;
-                        state.mu_n = -4.0;
-                    } else if (state.y_e < 0.5_rt) {
-                        state.mu_p = -10.0;
-                        state.mu_n = -6.0;
-                    } else {
-                        state.mu_p = -3.0;
-                        state.mu_n = -14.0;
-                    }
+                //     if (state.y_e < 0.45_rt) {
+                //         state.mu_p = -15.0;
+                //         state.mu_n = -4.0;
+                //     } else if (state.y_e < 0.5_rt) {
+                //         state.mu_p = -10.0;
+                //         state.mu_n = -6.0;
+                //     } else {
+                //         state.mu_p = -3.0;
+                //         state.mu_n = -14.0;
+                //     }
 
-                } else {
-                    // lower temperature
+                // } else {
+                //     // lower temperature
 
-                    if (state.y_e < 0.45_rt) {
-                        if (state.rho < 1.e8_rt) {
-                            state.mu_p = -14.0;
-                            state.mu_n = -5.0;
-                        } else {
-                            state.mu_p = -16.3;
-                            state.mu_n = -3.2;
-                        }
-                    } else if (state.y_e < 0.5_rt) {
-                        if (state.rho < 1.e8_rt) {
-                            state.mu_p = -6.0;
-                            state.mu_n = -11.0;
-                        } else {
-                            state.mu_p = -9.9;
-                            state.mu_n = -8.0;
-                        }
-                    } else {
-                        state.mu_p = -4.0;
-                        state.mu_n = -13.0;
-                    }
+                //     if (state.y_e < 0.45_rt) {
+                //         if (state.rho < 1.e8_rt) {
+                //             state.mu_p = -14.0;
+                //             state.mu_n = -5.0;
+                //         } else {
+                //             state.mu_p = -16.3;
+                //             state.mu_n = -3.2;
+                //         }
+                //     } else if (state.y_e < 0.5_rt) {
+                //         if (state.rho < 1.e8_rt) {
+                //             state.mu_p = -6.0;
+                //             state.mu_n = -11.0;
+                //         } else {
+                //             state.mu_p = -9.9;
+                //             state.mu_n = -8.0;
+                //         }
+                //     } else {
+                //         state.mu_p = -4.0;
+                //         state.mu_n = -13.0;
+                //     }
 
-                }
+                // }
 
                 // find the  nse state
 
                 const bool assume_ye_is_valid = true;
                 Real eps = 1.e-8;
-
+		use_hybrid_solver = 1;
                 auto nse_state = get_actual_nse_state(state, eps, assume_ye_is_valid);
                 std::cout << std::scientific;
                 std::cout << std::setw(20) << state.rho << " "

--- a/nse/make_table/burn_cell.H
+++ b/nse/make_table/burn_cell.H
@@ -51,8 +51,10 @@ void burn_cell_c()
                 const bool assume_ye_is_valid = true;
                 Real eps = 1.e-10;
 		use_hybrid_solver = 1;
+		
                 auto nse_state = get_actual_nse_state(state, eps, assume_ye_is_valid);
-                std::cout << std::scientific;
+
+		std::cout << std::scientific;
                 std::cout << std::setw(20) << state.rho << " "
                           << std::setw(20) << state.T << " " << std::fixed
                           << std::setw(20) << state.y_e << " "

--- a/nse/make_table/burn_cell.H
+++ b/nse/make_table/burn_cell.H
@@ -30,67 +30,26 @@ void burn_cell_c()
                 state.y_e = Ye;
 
 		if (state.y_e > 0.52_rt){
-		  state.mu_p = -2.0_rt;
-		  state.mu_n = -15.0_rt;
+		  state.mu_p = -1.0_rt;
+		  state.mu_n = -16.0_rt;
 		}
 		else if (state.y_e > 0.48_rt){
-		  state.mu_p = -7.0_rt;
+		  state.mu_p = -6.0_rt;
 		  state.mu_n = -11.0_rt;
 		}
 		else if (state.y_e > 0.4_rt){
 		  state.mu_p = -10.0_rt;
-		  state.mu_n = -8.0_rt;
+		  state.mu_n = -7.0_rt;
 		}
 		else{
-		  state.mu_p = -16.0;
-		  state.mu_n = -3.0;
-		}
-		
-                // initial guess
-
-                // if (state.T >= 4.5e9_rt) {
-
-                //     if (state.y_e < 0.45_rt) {
-                //         state.mu_p = -15.0;
-                //         state.mu_n = -4.0;
-                //     } else if (state.y_e < 0.5_rt) {
-                //         state.mu_p = -10.0;
-                //         state.mu_n = -6.0;
-                //     } else {
-                //         state.mu_p = -3.0;
-                //         state.mu_n = -14.0;
-                //     }
-
-                // } else {
-                //     // lower temperature
-
-                //     if (state.y_e < 0.45_rt) {
-                //         if (state.rho < 1.e8_rt) {
-                //             state.mu_p = -14.0;
-                //             state.mu_n = -5.0;
-                //         } else {
-                //             state.mu_p = -16.3;
-                //             state.mu_n = -3.2;
-                //         }
-                //     } else if (state.y_e < 0.5_rt) {
-                //         if (state.rho < 1.e8_rt) {
-                //             state.mu_p = -6.0;
-                //             state.mu_n = -11.0;
-                //         } else {
-                //             state.mu_p = -9.9;
-                //             state.mu_n = -8.0;
-                //         }
-                //     } else {
-                //         state.mu_p = -4.0;
-                //         state.mu_n = -13.0;
-                //     }
-
-                // }
+		  state.mu_p = -18.0;
+		  state.mu_n = -1.0;
+		}		
 
                 // find the  nse state
 
                 const bool assume_ye_is_valid = true;
-                Real eps = 1.e-8;
+                Real eps = 1.e-10;
 		use_hybrid_solver = 1;
                 auto nse_state = get_actual_nse_state(state, eps, assume_ye_is_valid);
                 std::cout << std::scientific;

--- a/unit_test/test_nse/GNUmakefile
+++ b/unit_test/test_nse/GNUmakefile
@@ -29,7 +29,7 @@ MICROPHYSICS_HOME  := ../..
 EOS_DIR     := helmholtz
 
 # This sets the network directory in Castro/Networks
-NETWORK_DIR := aprox21
+NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 

--- a/unit_test/test_nse/GNUmakefile
+++ b/unit_test/test_nse/GNUmakefile
@@ -29,7 +29,7 @@ MICROPHYSICS_HOME  := ../..
 EOS_DIR     := helmholtz
 
 # This sets the network directory in Castro/Networks
-NETWORK_DIR := aprox13
+NETWORK_DIR := aprox21
 
 CONDUCTIVITY_DIR := stellar
 

--- a/unit_test/test_nse/_parameters
+++ b/unit_test/test_nse/_parameters
@@ -34,5 +34,6 @@ X19           real       0.0d0
 X20           real       0.0d0
 X21           real       0.0d0
 
+y_e           real       0.4
 
 

--- a/unit_test/test_nse/_parameters
+++ b/unit_test/test_nse/_parameters
@@ -34,6 +34,6 @@ X19           real       0.0d0
 X20           real       0.0d0
 X21           real       0.0d0
 
-y_e           real       0.4
+y_e           real       0.5
 
 

--- a/unit_test/test_nse/inputs_aprox13
+++ b/unit_test/test_nse/inputs_aprox13
@@ -17,3 +17,5 @@ unit_test.X10 = 0.0
 unit_test.X11 = 0.0
 unit_test.X12 = 0.0
 unit_test.X13 = 0.0
+
+unit_test.y_e = 0.5

--- a/unit_test/test_nse/inputs_aprox19
+++ b/unit_test/test_nse/inputs_aprox19
@@ -26,3 +26,5 @@ unit_test.X19 = 0.0
 
 unit_test.mu_p = -3.0
 unit_test.mu_n = -12.0
+
+unit_test.y_e = 0.5

--- a/unit_test/test_nse/inputs_aprox21
+++ b/unit_test/test_nse/inputs_aprox21
@@ -28,5 +28,5 @@ unit_test.X21 = 0.01111111111
 
 unit_test.mu_p = -3.0
 unit_test.mu_n = -12.0
-unit_test.y_e = 0.4
 
+unit_test.y_e = 0.5

--- a/unit_test/test_nse/inputs_aprox21
+++ b/unit_test/test_nse/inputs_aprox21
@@ -28,3 +28,5 @@ unit_test.X21 = 0.01111111111
 
 unit_test.mu_p = -3.0
 unit_test.mu_n = -12.0
+unit_test.y_e = 0.4
+

--- a/unit_test/test_nse/inputs_iso7
+++ b/unit_test/test_nse/inputs_iso7
@@ -11,3 +11,6 @@ unit_test.X4  = 0.0
 unit_test.X5  = 0.0
 unit_test.X6  = 0.0
 unit_test.X7  = 0.0
+
+unit_test.y_e = 0.5
+

--- a/unit_test/test_nse/inputs_subch2
+++ b/unit_test/test_nse/inputs_subch2
@@ -20,3 +20,6 @@ unit_test.X13 = 0.0
 
 unit_test.mu_p = -3.0
 unit_test.mu_n = -12.0
+
+unit_test.y_e = 0.5
+

--- a/unit_test/test_nse/nse_example.H
+++ b/unit_test/test_nse/nse_example.H
@@ -104,14 +104,16 @@ void nse_example_c()
         state.xn[n] = massfractions[n];
     }
 
+    
     // normalize -- just in case
     
     normalize_abundances_burn(state);
 
     // compute the initial Ye
     
-    composition(state);
+    // composition(state);
 
+    state.y_e = y_e;
     std::cout << "electron fraction is " << state.y_e << std::endl;
 
     // set initial chemical potential of proton and neutron
@@ -119,12 +121,16 @@ void nse_example_c()
     state.mu_p = mu_p;
     state.mu_n = mu_n;
 
+
     std::cout << "chemical potential of proton is " << mu_p << std::endl;
     std::cout << "chemical potential of neutron is " << mu_n << std::endl;
 
+    
+    const bool assume_ye_valid = true;
+    amrex::Real eps = 1.0e-4_rt;
     // find the  nse state
-
-    auto NSE_STATE = get_actual_nse_state(state);
+    use_hybrid_solver = 1;
+    auto NSE_STATE = get_actual_nse_state(state, eps, assume_ye_valid);
 
     std::cout << "NSE state: " << std::endl;
     for (int n = 0; n < NumSpec; ++n) {

--- a/unit_test/test_nse/nse_example.H
+++ b/unit_test/test_nse/nse_example.H
@@ -111,9 +111,10 @@ void nse_example_c()
 
     // compute the initial Ye
     
-    // composition(state);
-
     state.y_e = y_e;
+    
+    // composition(state);
+    
     std::cout << "electron fraction is " << state.y_e << std::endl;
 
     // set initial chemical potential of proton and neutron
@@ -125,7 +126,8 @@ void nse_example_c()
     amrex::Real eps = 1.0e-10_rt;
     
     // find the  nse state
-    use_hybrid_solver = 0;
+    use_hybrid_solver = 1;
+    
     auto NSE_STATE = get_actual_nse_state(state, eps, assume_ye_valid);
 
     std::cout << "After solving: " << std::endl;

--- a/unit_test/test_nse/nse_example.H
+++ b/unit_test/test_nse/nse_example.H
@@ -120,18 +120,18 @@ void nse_example_c()
 
     state.mu_p = mu_p;
     state.mu_n = mu_n;
-
-
-    std::cout << "chemical potential of proton is " << mu_p << std::endl;
-    std::cout << "chemical potential of neutron is " << mu_n << std::endl;
-
     
     const bool assume_ye_valid = true;
-    amrex::Real eps = 1.0e-4_rt;
+    amrex::Real eps = 1.0e-10_rt;
+    
     // find the  nse state
-    use_hybrid_solver = 1;
+    use_hybrid_solver = 0;
     auto NSE_STATE = get_actual_nse_state(state, eps, assume_ye_valid);
 
+    std::cout << "After solving: " << std::endl;
+    std::cout << "chemical potential of proton is " << state.mu_p << std::endl;
+    std::cout << "chemical potential of neutron is " << state.mu_n << std::endl;
+    
     std::cout << "NSE state: " << std::endl;
     for (int n = 0; n < NumSpec; ++n) {
       std::cout << short_spec_names_cxx[n] << " : " << NSE_STATE.xn[n] << std::endl;


### PR DESCRIPTION
Done:
1) Tried to update n_e while doing iterations, but it turns out it doesn't improve convergence and can make it worse. So I discarded that idea.
2) Since scipy.fsolve also returns incorrect solutions with no errors were raised,  I guess it is how hybrj is supposed to work.
3) Added convergence check for hybrj
4) I think mode 1 works better actually? So I changed it back to mode 1...
5) Transplant the fine-tuning of initial guess procedure in pynucastro for scipy.fsolve to hybrj solver, making it more robust at solving nse.
6) change criteria for making the table of solving initial guesses. With fine-tuning, it is easier to solve them.
7) modify nr procedure to use constraint equations for hybrj (although it is almost never a case we should use nr over hybrj, especially with the fine-tuning procedure added)

Need to do:
1) Add partition function and spin state to complete it.