### PR TITLE
add the option to disable clipping species

### DIFF
--- a/integration/VODE/_parameters
+++ b/integration/VODE/_parameters
@@ -7,3 +7,6 @@ sdc_burn_tol_factor          real         1.d0
 # species that are > X_reject_buffer * atol_spec
 X_reject_buffer              real         1.0
 
+# in the clean_state process, do we clip the species such that they
+# are in [0, 1]?
+do_species_clip              int          1

--- a/integration/VODE/_parameters
+++ b/integration/VODE/_parameters
@@ -9,4 +9,4 @@ X_reject_buffer              real         1.0
 
 # in the clean_state process, do we clip the species such that they
 # are in [0, 1]?
-do_species_clip              int          1
+do_species_clip              integer          1

--- a/integration/VODE/vode_type_simplified_sdc.H
+++ b/integration/VODE/vode_type_simplified_sdc.H
@@ -30,7 +30,7 @@ void fill_unevolved_variables(const Real time, burn_t& state, const dvode_t& vod
 
     // we are always integrating from t = 0, so there is no offset
     // time needed here.  The indexing of ydot_a is based on
-    // the indices in burn_t and is 0-based
+    // the indices in burn_t and is 0-based    
     state.y[SRHO] = amrex::max(state.rho_orig + state.ydot_a[SRHO] * time, EOSData::mindens);
 
     // for consistency
@@ -171,12 +171,13 @@ void clean_state(const Real time, burn_t& state, dvode_t& vode_state)
 
     // Ensure that mass fractions always stay positive.
 
-    for (int n = 1; n <= NumSpec; ++n) {
-        // we use 1-based indexing, so we need to offset SFS
-        vode_state.y(SFS+n) = amrex::max(amrex::min(vode_state.y(SFS+n), state.rho),
-                                         state.rho * SMALL_X_SAFE);
+    if (do_species_clip) {
+        for (int n = 1; n <= NumSpec; ++n) {
+            // we use 1-based indexing, so we need to offset SFS
+            vode_state.y(SFS+n) = amrex::max(amrex::min(vode_state.y(SFS+n), state.rho),
+                                             state.rho * SMALL_X_SAFE);
+        }
     }
-
 
     // renormalize abundances as necessary
 

--- a/integration/VODE/vode_type_strang.H
+++ b/integration/VODE/vode_type_strang.H
@@ -53,8 +53,10 @@ void clean_state (dvode_t& vode_state)
     // Ensure that mass fractions always stay positive and less than or
     // equal to 1.
 
-    for (int n = 1; n <= NumSpec; ++n) {
-        vode_state.y(n) = amrex::max(amrex::min(vode_state.y(n), 1.0_rt), SMALL_X_SAFE);
+    if (do_species_clip) {
+        for (int n = 1; n <= NumSpec; ++n) {
+            vode_state.y(n) = amrex::max(amrex::min(vode_state.y(n), 1.0_rt), SMALL_X_SAFE);
+        }
     }
 
     // Renormalize the abundances as necessary.


### PR DESCRIPTION
currently for both Strang and simplfiied-SDC integration, we clip the species in clean_state to lie in [0, 1].  But we already have step rejection logic that enforces this, and some testing shows that this clipping makes VODE work a lot harder.