### PR TITLE
some fixes to burn_cell to allow for pynucastro python comparison

### DIFF
--- a/unit_test/burn_cell/_parameters
+++ b/unit_test/burn_cell/_parameters
@@ -41,4 +41,4 @@ X20           real       0.0d0
 X21           real       0.0d0
 
 
-
+skip_initial_normalization    int    0

--- a/unit_test/burn_cell/burn_cell.H
+++ b/unit_test/burn_cell/burn_cell.H
@@ -106,7 +106,9 @@ void burn_cell_c()
 
     // normalize -- just in case
 
-    normalize_abundances_burn(state);
+    if (! skip_initial_normalization) {
+        normalize_abundances_burn(state);
+    }
 
     // output just the instantaneous RHS
 
@@ -203,7 +205,9 @@ void burn_cell_c()
 
         // get the updated T
 
-        eos(eos_input_re, state);
+        if (call_eos_in_rhs) {
+            eos(eos_input_re, state);
+        }
 
         t += dt;
 
@@ -233,7 +237,8 @@ void burn_cell_c()
     std::cout << "------------------------------------" << std::endl;
     std::cout << "new mass fractions: " << std::endl;
     for (int n = 0; n < NumSpec; ++n) {
-        std::cout << state.xn[n] << std::endl;
+        std::string element = short_spec_names_cxx[n];
+        std::cout << element << " " << state.xn[n] << std::endl;
     }
 
     std::cout << "------------------------------------" << std::endl;

--- a/unit_test/burn_cell/inputs_subch_compare
+++ b/unit_test/burn_cell/inputs_subch_compare
@@ -11,21 +11,21 @@ integrator.burner_verbose = 0
 # 1 = analytic jacobian
 # 2 = numerical jacobian
 
-integrator.jacobian = 2
+integrator.jacobian = 1
 
 integrator.renormalize_abundances = 0
 
 integrator.rtol_spec = 1.0e-6
 integrator.rtol_enuc = 1.0e-6
-integrator.atol_spec = 1.0e-6
+integrator.atol_spec = 1.0e-10
 integrator.atol_enuc = 1.0e-6
 
-unit_test.tmax = 5.e-2
-unit_test.tfirst = 1.e-5
+unit_test.tmax = 1.e-3
+unit_test.tfirst = 1.e-10
 unit_test.nsteps = 100
 
 unit_test.density = 1.e6
-unit_test.temperature = 3.e9
+unit_test.temperature = 2.e9
 
 unit_test.X1 = 0.0
 unit_test.X2  = 0.99
@@ -40,3 +40,10 @@ unit_test.X10 = 0.0
 unit_test.X11 = 0.0
 unit_test.X12 = 0.0
 unit_test.X13 = 0.0
+
+integrator.integrate_energy = 0
+integrator.call_eos_in_rhs = 0
+
+integrator.do_species_clip = 0
+
+unit_test.skip_initial_normalization = 1


### PR DESCRIPTION
this fixes the no-energy evolution, outputs some more detail
and has an inputs file that correctly sets up the burn to match python