### PR TITLE
Add a null screening routine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 22.10
+
+  * A null screening routine was added to disable screening for any network at
+    compile time. (#992)
+
 # 22.09
 
   * An NSE solver was added (#963)

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -26,6 +26,8 @@ else ifeq ($(SCREEN_METHOD), chugunov2007)
   DEFINES += -DSCREEN_METHOD=1
 else ifeq ($(SCREEN_METHOD), chugunov2009)
   DEFINES += -DSCREEN_METHOD=2
+else ifeq ($(SCREEN_METHOD), null)
+  DEFINES += -DSCREEN_METHOD=3
 endif
 
 ifeq ($(EOS_DIR), gamma_law_general)

--- a/screening/screen.H
+++ b/screening/screen.H
@@ -21,6 +21,8 @@ const std::string screen_name = "screen5";
 const std::string screen_name = "chugunov2007";
 #elif SCREEN_METHOD == 2
 const std::string screen_name = "chugunov2009";
+#elif SCREEN_METHOD == 3
+const std::string screen_name = "null";
 #endif
 
 struct plasma_state_t {
@@ -768,6 +770,10 @@ void actual_screen(const plasma_state_t& state,
     chugunov2007<do_T_derivatives>(state, scn_fac, scor, scordt);
 #elif SCREEN_METHOD == 2
     chugunov2009<do_T_derivatives>(state, scn_fac, scor, scordt);
+#elif SCREEN_METHOD == 3
+    // null screening
+    scor = 1.0_rt;
+    scordt = 0.0_rt;
 #endif
 }
 

--- a/sphinx_docs/source/screening.rst
+++ b/sphinx_docs/source/screening.rst
@@ -38,3 +38,8 @@ The options are:
 
   This includes the portion in the appendix that blends in the weak
   screening limit.
+
+* ``null`` :
+
+  This disables screening by always returning 1 for the screening
+  enhancement factor.


### PR DESCRIPTION
Selected by `SCREEN_METHOD=null`, closes #984