### PR TITLE
fix an EOS call with NSE

### DIFF
--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -75,6 +75,11 @@ void actual_integrator (burn_t& state, Real dt)
     // compute the temperature based on the energy release -- we need 
     // this in case we failed in our burn here because we entered NSE
 
+#ifdef AUX_THERMO
+    // need to sync the auxilary data up with the new mass fractions
+    set_aux_comp_from_X(state);
+#endif
+
     eos(eos_input_re, state);
 
 #endif

--- a/unit_test/burn_cell/ci-benchmarks/aprox19_nse_unit_test.out
+++ b/unit_test/burn_cell/ci-benchmarks/aprox19_nse_unit_test.out
@@ -1,4 +1,4 @@
-AMReX (22.12-7-ga141ca6edfd6) initialized
+AMReX (23.01-12-ga05384c0b7c4) initialized
 starting the single zone burn...
 reading the NSE table (C++) ...
 Maximum Time (s): 0.01
@@ -47,53 +47,53 @@ burn entered NSE during integration (after 280 steps), zone = (0, 0, 0)
 recovering burn failure in NSE, zone = (0, 0, 0)
 ------------------------------------
 successful? 1
- - Hnuc = 1.71409534e+21
- - added e = 1.71409534e+19
- - final T = 9682592587
+ - Hnuc = 1.722639683e+21
+ - added e = 1.722639683e+19
+ - final T = 9693314581
 ------------------------------------
 e initial = 1.516256085e+18
-e final =   1.865720949e+19
+e final =   1.874265292e+19
 ------------------------------------
 new mass fractions: 
-H1 1.507769781e-05
-He3 9.999999999e-31
-He4 0.3743494174
-C12 5.525298198e-09
-N14 4.723804371e-12
-O16 2.386350002e-11
-Ne20 9.617000592e-15
-Mg24 4.1924729e-16
-Si28 3.829921711e-17
-S32 9.999999999e-31
-Ar36 9.999999999e-31
-Ca40 9.999999999e-31
-Ti44 9.999999999e-31
-Cr48 4.976261295e-30
-Fe52 9.999999999e-31
-Fe54 9.999999999e-31
-Ni56 9.999999999e-31
-n 0.3121397751
-p 0.3134957242
+H1 1.773185098e-05
+He3 3.42332115e-10
+He4 0.3696571637
+C12 5.254254801e-09
+N14 5.343243023e-12
+O16 9.999973846e-31
+Ne20 9.721662664e-15
+Mg24 9.999973846e-31
+Si28 8.028487683e-17
+S32 1.783705413e-19
+Ar36 2.638532578e-22
+Ca40 6.095894533e-25
+Ti44 1.429715151e-28
+Cr48 9.999973846e-31
+Fe52 3.588465429e-30
+Fe54 9.999973846e-31
+Ni56 9.999973846e-31
+n 0.3144714029
+p 0.3158536959
 ------------------------------------
 species creation rates: 
-omegadot(H1): -9.99849223
-omegadot(He3): -2.5
-omegadot(He4): -42.56505826
-omegadot(C12): -2.499999447
-omegadot(N14): -2.5
-omegadot(O16): -2.499999998
-omegadot(Ne20): 9.617000592e-13
-omegadot(Mg24): 4.1924729e-14
-omegadot(Si28): 3.829921711e-15
-omegadot(S32): -1.148257243e-38
-omegadot(Ar36): -1.148257243e-38
-omegadot(Ca40): -1.148257243e-38
-omegadot(Ti44): -1.148257243e-38
-omegadot(Cr48): 3.976261295e-28
-omegadot(Fe52): -1.148257243e-38
-omegadot(Fe54): -1.148257243e-38
-omegadot(Ni56): -1.148257243e-38
-omegadot(n): 31.21397751
-omegadot(p): 31.34957242
-number of steps taken: 33642
-AMReX (22.12-7-ga141ca6edfd6) finalized
+omegadot(H1): -9.998226815
+omegadot(He3): -2.499999966
+omegadot(He4): -43.03428363
+omegadot(C12): -2.499999475
+omegadot(N14): -2.499999999
+omegadot(O16): -2.5
+omegadot(Ne20): 9.721662664e-13
+omegadot(Mg24): -2.615409947e-34
+omegadot(Si28): 8.028487683e-15
+omegadot(S32): 1.783705413e-17
+omegadot(Ar36): 2.638532568e-20
+omegadot(Ca40): 6.095884533e-23
+omegadot(Ti44): 1.419715151e-26
+omegadot(Cr48): -2.615409947e-34
+omegadot(Fe52): 2.588465429e-28
+omegadot(Fe54): -2.615409947e-34
+omegadot(Ni56): -2.615409947e-34
+omegadot(n): 31.44714029
+omegadot(p): 31.58536959
+number of steps taken: 33488
+AMReX (23.01-12-ga05384c0b7c4) finalized


### PR DESCRIPTION
after integrating, we call the EOS to get T in case we complete the burn with NSE, but we were not setting the aux data to be consistent with the mass fractions, so we got the thermodynamics wrong.