### PR TITLE
swtich Strang over to use T_fixed + update SDC + NSE

### DIFF
--- a/integration/integrator_type_strang.H
+++ b/integration/integrator_type_strang.H
@@ -117,6 +117,13 @@ void update_thermodynamics (burn_t& state, const I& int_state)
     if (call_eos_in_rhs) {
         eos(eos_input_re, state);
     }
+
+    // override T if we are fixing it (e.g. due to
+    // drive_initial_convection)
+    if (state.T_fixed > 0.0_rt) {
+        state.T = state.T_fixed;
+    }
+
 }
 
 #endif

--- a/integration/nse_update.H
+++ b/integration/nse_update.H
@@ -114,7 +114,7 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
             T_new = state.T_fixed;
         } else {
             eos(eos_input_re, eos_state);
-            T_new = state.T_fixed;
+            T_new = state.T;
         }
 
 #if defined(NSE_TABLE)

--- a/integration/nse_update.H
+++ b/integration/nse_update.H
@@ -46,10 +46,15 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
 
     Real ye_in = state.y[SFX+iye] / state.rho;
 
+    // if we are doing drive_initial_convection, we want to use
+    // the temperature that comes in through T_fixed
+
+    Real T_in = state.T_fixed > 0.0_rt ? state.T_fixed : state.T;
+
 #if defined (NSE_TABLE)
     // get the current NSE state from the table
 
-    nse_interp(state.T, state.rho, ye_in,
+    nse_interp(T_in, state.rho, ye_in,
                abar_out, dq_out, dyedt, X);
 
 #elif defined (NSE_NET)
@@ -98,19 +103,25 @@ void sdc_nse_burn(burn_t& state, const Real dt) {
 
         // call the EOS to get the updated T*
 
+        Real T_new;
         eos_state.rho = state.y[SRHO];
         eos_state.e = rhoe_new / state.y[SRHO];
         for (int n = 0; n < NumAux; n++) {
             eos_state.aux[n] = rho_aux_new[n] / state.y[SRHO];
         }
 
-        eos(eos_input_re, eos_state);
+        if (state.T_fixed > 0) {
+            T_new = state.T_fixed;
+        } else {
+            eos(eos_input_re, eos_state);
+            T_new = state.T_fixed;
+        }
 
 #if defined(NSE_TABLE)
         // call the NSE table using the * state to get the t^{n+1}
         // source estimates
 
-        nse_interp(eos_state.T, eos_state.rho, eos_state.aux[iye],
+        nse_interp(T_new, eos_state.rho, eos_state.aux[iye],
                    abar_out, dq_out, dyedt, X);
 
 #elif defined(NSE_NET)
@@ -192,11 +203,16 @@ void nse_burn(burn_t& state, const Real dt) {
 
   eos(eos_input_rt, state);
 
+  // if we are doing drive_initial_convection, we want to use
+  // the temperature that comes in through T_fixed
+
+  Real T_in = state.T_fixed > 0.0_rt ? state.T_fixed : state.T;
+
   // call the NSE table using the * state to get the t^{n+1}
   // source estimates.  The thermodynamnics here is specified
   // in terms of the auxillary composition, Ye, abar, and B/A
 
-  nse_interp(state.T, state.rho, state.aux[iye],
+  nse_interp(T_in, state.rho, state.aux[iye],
              abar_out, dq_out, dyedt, X);
 
   // update Ye
@@ -205,7 +221,7 @@ void nse_burn(burn_t& state, const Real dt) {
 
   // now get the composition from the table using the upated Ye
 
-  nse_interp(state.T, state.rho, state.aux[iye],
+  nse_interp(T_in, state.rho, state.aux[iye],
              abar_out, dq_out, dyedt, X);
 
 

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -149,7 +149,7 @@ struct burn_t
   // for drive_initial_convection, we will fix T during the
   // integration to a passed in value.  We will interpret a positive
   // T_fixed as setting this feature.
-  Real T_fixed;
+  Real T_fixed{-1.0};
 
   // all coupling types need the specific heats to transform the
   // reaction Jacobian elements from T to e

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -144,12 +144,12 @@ struct burn_t
   int sdc_iter;
   int num_sdc_iters;
 
+#endif
+
   // for drive_initial_convection, we will fix T during the
   // integration to a passed in value.  We will interpret a positive
   // T_fixed as setting this feature.
   Real T_fixed;
-
-#endif
 
   // all coupling types need the specific heats to transform the
   // reaction Jacobian elements from T to e

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -294,7 +294,7 @@ T get_nse_state(const T& state)
 
       nse_state.xn[n] = network::mion(n+1) * pf * spin / state.rho *
           std::pow(2.0 * M_PI * network::mion(n+1) *
-                   C::k_B * T_n / std::pow(C::hplanck, 2.0_rt), 3.0_rt/2.0_rt) *
+                   C::k_B * T_in / std::pow(C::hplanck, 2.0_rt), 3.0_rt/2.0_rt) *
           std::exp(exponent);
   }
 

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -242,8 +242,13 @@ T get_nse_state(const T& state)
   amrex::Real dpf_dT;
   amrex::Real spin = 1.0_rt;
 
+  // if we are doing drive_initial_convection, we want to use
+  // the temperature that comes in through T_fixed
+
+  Real T_in = state.T_fixed > 0.0_rt ? state.T_fixed : state.T;
+
 #ifdef TFACTORS_H
-  auto tfactors = evaluate_tfactors(state.T);
+  auto tfactors = evaluate_tfactors(T_in);
 #endif
 
   for (int n = 0; n < NumSpec; ++n){
@@ -259,11 +264,11 @@ T get_nse_state(const T& state)
 #else
       gamma = std::pow(zion[n], 5.0_rt/3.0_rt) *
           C::q_e * C::q_e * std::cbrt(4.0_rt * M_PI * n_e / 3.0_rt) /
-          (C::k_B * state.T);
+          (C::k_B * T_in);
 
       // chemical potential for coulomb correction
 
-      u_c = C::k_B * state.T / C::Legacy::MeV2erg *
+      u_c = C::k_B * T_in / C::Legacy::MeV2erg *
           (A1 * (std::sqrt(gamma * (A2 + gamma)) -
                  A2 * std::log(std::sqrt(gamma / A2) +
                                std::sqrt(1.0_rt + gamma / A2))) +
@@ -285,11 +290,11 @@ T get_nse_state(const T& state)
       Real exponent = amrex::min(500.0_rt,
                                  (zion[n] * state.mu_p + (aion[n] - zion[n]) * state.mu_n
                                   - u_c + network::bion(n+1)) /
-                                 C::k_B / state.T * C::Legacy::MeV2erg);
+                                 C::k_B / T_in * C::Legacy::MeV2erg);
 
       nse_state.xn[n] = network::mion(n+1) * pf * spin / state.rho *
           std::pow(2.0 * M_PI * network::mion(n+1) *
-                   C::k_B * state.T / std::pow(C::hplanck, 2.0_rt), 3.0_rt/2.0_rt) *
+                   C::k_B * T_n / std::pow(C::hplanck, 2.0_rt), 3.0_rt/2.0_rt) *
           std::exp(exponent);
   }
 
@@ -305,7 +310,7 @@ T get_nse_state(const T& state)
     nse_state.y_e += nse_state.xn[n] * zion[n] * aion_inv[n];
   }
 
-  nse_state.T = state.T;
+  nse_state.T = T_in;
   nse_state.rho = state.rho;
 
   return nse_state;
@@ -364,15 +369,20 @@ void jcn_hybrid(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
     fjac(2, 1) = 0.0_rt;
     fjac(2, 2) = 0.0_rt;
 
+    // if we are doing drive_initial_convection, we want to use
+    // the temperature that comes in through T_fixed
+
+    Real T_in = state.T_fixed > 0.0_rt ? state.T_fixed : state.T;
+
     for (int n = 0; n < NumSpec; ++n){
         if (n == NSE_INDEX::h1_index){
             continue;
         }
 
-        fjac(1, 1) += nse_state.xn[n] * zion[n] / C::k_B / state.T * C::Legacy::MeV2erg ;
-        fjac(1, 2) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / state.T * C::Legacy::MeV2erg;
-        fjac(2, 1) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
-        fjac(2, 2) += nse_state.xn[n] * zion[n] * (aion[n] - zion[n]) * aion_inv[n] / C::k_B / state.T * C::Legacy::MeV2erg;
+        fjac(1, 1) += nse_state.xn[n] * zion[n] / C::k_B / T_in * C::Legacy::MeV2erg ;
+        fjac(1, 2) += nse_state.xn[n] * (aion[n] - zion[n]) / C::k_B / T_in * C::Legacy::MeV2erg;
+        fjac(2, 1) += nse_state.xn[n] * zion[n] * zion[n] * aion_inv[n] / C::k_B / T_in * C::Legacy::MeV2erg;
+        fjac(2, 2) += nse_state.xn[n] * zion[n] * (aion[n] - zion[n]) * aion_inv[n] / C::k_B / T_in * C::Legacy::MeV2erg;
     }
 
 }

--- a/unit_test/burn_cell/burn_cell.H
+++ b/unit_test/burn_cell/burn_cell.H
@@ -41,7 +41,7 @@ void burn_cell_c()
     eos_state.rho = density;
     eos_state.T = temperature;
     for (int n = 0; n < NumSpec; n++) {
-      eos_state.xn[n] = massfractions[n];
+        eos_state.xn[n] = massfractions[n];
     }
 #ifdef AUX_THERMO
     set_aux_comp_from_X(eos_state);
@@ -63,6 +63,7 @@ void burn_cell_c()
     burn_state.i = 0;
     burn_state.j = 0;
     burn_state.k = 0;
+    burn_state.T_fixed = -1.0_rt;
 
     // normalize -- just in case
 

--- a/unit_test/test_react/react_zones.H
+++ b/unit_test/test_react/react_zones.H
@@ -42,6 +42,8 @@ bool do_react (int i, int j, int k, Array4<Real> const& state,
     burn_state.reference_time = 0.0;
 #endif
 
+    burn_state.T_fixed = -1.0_rt;
+
     burner(burn_state, dt);
 
     for (int n = 0; n < NumSpec; ++n) {


### PR DESCRIPTION
we were not being consistent with how we handled T_fixed, which is set if we are doing drive_initial_convection (Castro Strang update coming soon).  The idea is that the zone's internal energy should not be computed off of T_fixed, but all of the reaction rates should be.  This update fixes some issues with NSE and Strang burning where were we computing e with T_fixed, thus changing the amount of internal energy in a zone.