### PR TITLE
some cleaning for the NSE table

### DIFF
--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -33,11 +33,12 @@ namespace network
 namespace table
 {
 
-  constexpr int npts = 46221;
 
   constexpr int ntemp = 71;
   constexpr int nden = 31;
   constexpr int nye = 21;
+
+  constexpr int npts = ntemp * nden * nye;
 
   constexpr Real dlogT = 0.02_rt;
   constexpr Real dlogrho = 0.10_rt;

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -39,9 +39,9 @@ namespace table
   constexpr int nden = 31;
   constexpr int nye = 21;
 
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ttlog;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ddlog;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> yetab;
+  constexpr Real dlogT = 0.02_rt;
+  constexpr Real dlogrho = 0.10_rt;
+  constexpr Real dye = 0.005_rt;
 
   extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> abartab;
   extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ebtab;

--- a/networks/aprox19/actual_network_data.cpp
+++ b/networks/aprox19/actual_network_data.cpp
@@ -14,10 +14,6 @@ namespace network
 namespace table
 {
 
-  AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ttlog;
-  AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ddlog;
-  AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> yetab;
-
   AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> abartab;
   AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ebtab;
   AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> wratetab;

--- a/networks/aprox19/nse_table.H
+++ b/networks/aprox19/nse_table.H
@@ -71,6 +71,33 @@ Real nse_table_ye(const int ic) {
     return 0.50_rt - static_cast<Real>(ic-1) * table::dye;
 }
 
+// return the index in the table such that logrho[irho] < input density
+// note: this is a 1-based index
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+int nse_get_logrho_index(const Real logrho) {
+
+    int ir0 = static_cast<int>((logrho - 7.0_rt) / table::dlogrho - 1.e-6_rt);
+    return ir0 + 1;
+}
+
+// return the index in the table such that logT[it] < input temperature
+// note: this is a 1-based index
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+int nse_get_logT_index(const Real logT) {
+
+    int it0 = static_cast<int>((logT - 9.0_rt) / table::dlogT - 1.e-6_rt);
+    return it0 + 1;
+}
+
+// return the index in the table such that ye[ic] < input Ye
+// note: this is a 1-based index
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+int nse_get_ye_index(const Real ye) {
+
+    int ic0 = static_cast<int>((0.50_rt - ye) / table::dye - 1.0e-6_rt);
+    return ic0 + 1;
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_interp(const Real T, const Real rho, const Real ye,
                 Real& abar, Real& dq, Real& dyedt, Real* X) {
@@ -82,40 +109,17 @@ void nse_interp(const Real T, const Real rho, const Real ye,
   Real rholog = std::log10(rho);
   Real yet = ye;
 
-  if (tlog < 9.0_rt) {
-    tlog = 9.0_rt;
-  }
+  Real rholog = amrex::max(7.0_rt, amrex::min(10.0_rt, std::log10(rho)));
+  Real tlog = amrex::max(9.0_rt, amrex::min(10.4_rt, std::log10(T)));
+  Real yet = amrex::max(0.40_rt, amrex::min(0.50_rt, ye));
 
-  if (tlog > 10.4_rt) {
-    tlog = 10.4_rt;
-  }
-
-  int it1 = static_cast<int>((tlog - 9.0_rt) / table::dlogT - 1.e-6_rt);
-  it1 += 1;
-  int it2 = it1 + 1;
-
-  if (rholog < 7.0_rt) {
-    rholog = 7.0_rt;
-  }
-
-  if (rholog > 10.0_rt) {
-    rholog = 10.0_rt;
-  }
-
-  int ir1 = static_cast<int>((rholog - 7.0_rt) / table::dlogrho - 1.e-6_rt);
-  ir1 += 1;
+  int ir1 = nse_get_logrho_index(rholog);
   int ir2 = ir1 + 1;
 
-  if (yet < 0.40_rt) {
-    yet = 0.40_rt;
-  }
+  int it1 = nse_get_logT_index(tlog);
+  int it2 = it1 + 1;
 
-  if (yet > 0.50_rt) {
-    yet = 0.50_rt;
-  }
-
-  int ic1 = static_cast<int>((0.50_rt - yet) / table::dye - 1.0e-6_rt);
-  ic1 += 1;
+  int ic1 = nse_get_ye_index(yet);
   int ic2 = ic1 + 1;
 
   // find the eight interpolation points in the 1D arrays

--- a/networks/aprox19/nse_table.H
+++ b/networks/aprox19/nse_table.H
@@ -105,10 +105,6 @@ void nse_interp(const Real T, const Real rho, const Real ye,
   using namespace table;
   using namespace AuxZero;
 
-  Real tlog = std::log10(T);
-  Real rholog = std::log10(rho);
-  Real yet = ye;
-
   Real rholog = amrex::max(7.0_rt, amrex::min(10.0_rt, std::log10(rho)));
   Real tlog = amrex::max(9.0_rt, amrex::min(10.4_rt, std::log10(T)));
   Real yet = amrex::max(0.40_rt, amrex::min(0.50_rt, ye));

--- a/networks/aprox19/nse_table.H
+++ b/networks/aprox19/nse_table.H
@@ -31,13 +31,14 @@ void init_nse() {
   nse_table.open("nse19.tbl", std::ios::in);
 
   Real the, tsi, tfe;
+  Real ttemp, tdens, tye;
 
   for (int irho = 1; irho <= table::nden; irho++) {
     for (int it9 = 1; it9 <= table::ntemp; it9++) {
       for (int iye = 1; iye <= table::nye; iye++) {
         int j = (irho-1)*table::ntemp*table::nye + (it9-1)*table::nye + iye;
 
-        nse_table >> table::ttlog(j) >> table::ddlog(j) >> table::yetab(j);
+        nse_table >> ttemp >> tdens >> tye;
         nse_table >> the >> tsi >> tfe;
         nse_table >> table::abartab(j) >> table::ebtab(j) >> table::wratetab(j);
         for (int n = 1; n <= NumSpec; n++) {
@@ -49,6 +50,10 @@ void init_nse() {
 
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+int nse_idx(const int ir, const int it, const int ic) {
+    return (ir-1) * table::ntemp * table::nye + (it-1) * table::nye + ic;
+}
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_interp(const Real T, const Real rho, const Real ye,
@@ -69,7 +74,7 @@ void nse_interp(const Real T, const Real rho, const Real ye,
     tlog = 10.4_rt;
   }
 
-  int it1 = static_cast<int>((tlog - 9.0_rt)*50.0_rt - 1.e-6_rt);
+  int it1 = static_cast<int>((tlog - 9.0_rt) / table::dlogT - 1.e-6_rt);
   it1 += 1;
   int it2 = it1 + 1;
 
@@ -81,7 +86,7 @@ void nse_interp(const Real T, const Real rho, const Real ye,
     rholog = 10.0_rt;
   }
 
-  int ir1 = static_cast<int>((rholog - 7.0_rt)*10.0_rt - 1.e-6_rt);
+  int ir1 = static_cast<int>((rholog - 7.0_rt) / table::dlogrho - 1.e-6_rt);
   ir1 += 1;
   int ir2 = ir1 + 1;
 
@@ -93,28 +98,28 @@ void nse_interp(const Real T, const Real rho, const Real ye,
     yet = 0.50_rt;
   }
 
-  int ic1 = static_cast<int>((0.50_rt - yet)/0.005_rt - 1.0e-6_rt);
+  int ic1 = static_cast<int>((0.50_rt - yet) / table::dye - 1.0e-6_rt);
   ic1 += 1;
   int ic2 = ic1 + 1;
 
   // find the eight interpolation points in the 1D arrays
 
-  int it1r1c1 = (ir1-1)*71*21 + (it1-1)*21 + ic1;
-  int it1r1c2 = (ir1-1)*71*21 + (it1-1)*21 + ic2;
-  int it1r2c1 = (ir2-1)*71*21 + (it1-1)*21 + ic1;
-  int it1r2c2 = (ir2-1)*71*21 + (it1-1)*21 + ic2;
-  int it2r1c1 = (ir1-1)*71*21 + (it2-1)*21 + ic1;
-  int it2r1c2 = (ir1-1)*71*21 + (it2-1)*21 + ic2;
-  int it2r2c1 = (ir2-1)*71*21 + (it2-1)*21 + ic1;
-  int it2r2c2 = (ir2-1)*71*21 + (it2-1)*21 + ic2;
+  int it1r1c1 = nse_idx(ir1, it1, ic1);
+  int it1r1c2 = nse_idx(ir1, it1, ic2);
+  int it1r2c1 = nse_idx(ir2, it1, ic1);
+  int it1r2c2 = nse_idx(ir2, it1, ic2);
+  int it2r1c1 = nse_idx(ir1, it2, ic1);
+  int it2r1c2 = nse_idx(ir1, it2, ic2);
+  int it2r2c1 = nse_idx(ir2, it2, ic1);
+  int it2r2c2 = nse_idx(ir2, it2, ic2);
 
-  Real t0 = 9.0_rt + static_cast<Real>(it1-1)*0.02_rt;
-  Real r0 = 7.0_rt + static_cast<Real>(ir1-1)*0.10_rt;
-  Real x0 = 0.50_rt - static_cast<Real>(ic1-1)*0.005_rt;
+  Real t0 = 9.0_rt + static_cast<Real>(it1-1) * table::dlogT;
+  Real r0 = 7.0_rt + static_cast<Real>(ir1-1) * table::dlogrho;
+  Real x0 = 0.50_rt - static_cast<Real>(ic1-1) * table::dye;
 
-  Real td = (tlog - t0)/0.02_rt;
-  Real rd = (rholog - r0)/0.10_rt;
-  Real xd = (x0-yet)/0.005_rt;
+  Real td = (tlog - t0) / table::dlogT;
+  Real rd = (rholog - r0) / table::dlogrho;
+  Real xd = (x0-yet) / table::dye;
   xd = amrex::max(0.0_rt, xd);
 
   Real omtd = 1.0_rt - td;

--- a/networks/aprox19/nse_table.H
+++ b/networks/aprox19/nse_table.H
@@ -52,7 +52,23 @@ void init_nse() {
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 int nse_idx(const int ir, const int it, const int ic) {
+    // this uses a 1-based indexing
     return (ir-1) * table::ntemp * table::nye + (it-1) * table::nye + ic;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real nse_table_logT(const int it) {
+    return 9.0_rt + static_cast<Real>(it-1) * table::dlogT;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real nse_table_logrho(const int ir) {
+    return 7.0_rt + static_cast<Real>(ir-1) * table::dlogrho;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+Real nse_table_ye(const int ic) {
+    return 0.50_rt - static_cast<Real>(ic-1) * table::dye;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
@@ -113,9 +129,9 @@ void nse_interp(const Real T, const Real rho, const Real ye,
   int it2r2c1 = nse_idx(ir2, it2, ic1);
   int it2r2c2 = nse_idx(ir2, it2, ic2);
 
-  Real t0 = 9.0_rt + static_cast<Real>(it1-1) * table::dlogT;
-  Real r0 = 7.0_rt + static_cast<Real>(ir1-1) * table::dlogrho;
-  Real x0 = 0.50_rt - static_cast<Real>(ic1-1) * table::dye;
+  Real t0 = nse_table_logT(it1);
+  Real r0 = nse_table_logrho(ir1);
+  Real x0 = nse_table_ye(ic1);
 
   Real td = (tlog - t0) / table::dlogT;
   Real rd = (rholog - r0) / table::dlogrho;

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -26,27 +26,6 @@ namespace network
     extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
 }
 
-namespace table
-{
-
-  constexpr int npts = 46221;
-
-  constexpr int ntemp = 71;
-  constexpr int nden = 31;
-  constexpr int nye = 21;
-
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ttlog;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ddlog;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> yetab;
-
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> abartab;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> ebtab;
-  extern AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, npts> wratetab;
-
-  extern AMREX_GPU_MANAGED amrex::Array2D<amrex::Real, 1, NumSpec, 1, npts> massfractab;
-
-}
-
 
 namespace Rates {
     enum NetworkRates {

--- a/sphinx_docs/source/nse.rst
+++ b/sphinx_docs/source/nse.rst
@@ -178,6 +178,18 @@ We determine is a zone is in NSE according to:
 
 .. _self_consistent_nse:
 
+
+NSE table ranges
+----------------
+
+The NSE table was created for:
+
+* :math:`9 < \log_{10}(T) < 10.4`
+* :math:`7 < \log_{10}(\rho) < 10`
+* :math:`0.4 < Y_e < 0.5`
+
+
+
 Self-consistent NSE
 ===================
 


### PR DESCRIPTION
there is now a table_idx() function that can be used to get the correct index into the 1-d table.
this makes new constexpr for the table deltas
eliminates arrays to store T, rho, ye at the table points, since those are easily computed
replaces some magic numbers with more consts