### PR TITLE
Explicitly initialize rates to 0 in tabulate_rates

### DIFF
--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -632,17 +632,15 @@ void tabulate_rates ()
             [[maybe_unused]] constexpr int rate = n;
 
             rate_t rates;
+            rates.fr = 0.0_rt;
+            rates.rr = 0.0_rt;
+            rates.frdt = 0.0_rt;
+            rates.rrdt = 0.0_rt;
 
             constexpr rhs_t data = RHS::rhs_data(rate);
 
             if constexpr (data.rate_can_be_tabulated) {
                 evaluate_analytical_rate<rate>(state, rates);
-            }
-            else {
-                rates.fr = 0.0_rt;
-                rates.rr = 0.0_rt;
-                rates.frdt = 0.0_rt;
-                rates.rrdt = 0.0_rt;
             }
 
             rattab(rate, 1, i)    = rates.fr;


### PR DESCRIPTION
Fixes uninitialized memory errors in aprox19 and aprox21 introduced by #1054.