### PR TITLE
add an option to ignore checking the timescale of the rate for NSE_NET

### DIFF
--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -136,6 +136,10 @@ ifeq ($(USE_NSE_NET), TRUE)
      DEFINES += -DNSE_NET
      DEFINES += -DNSE
 
+     ifeq ($(DISABLE_NSE_DX_DEPENDENT), TRUE)
+     	  DEFINES += -DNSE_DX_INDEPENDENT
+     endif
+     
      EXTERN_CORE += $(MICROPHYSICS_HOME)/nse_solver
      EXTERN_CORE += $(MICROPHYSICS_HOME)/util/hybrj
 endif

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -136,10 +136,6 @@ ifeq ($(USE_NSE_NET), TRUE)
      DEFINES += -DNSE_NET
      DEFINES += -DNSE
 
-     ifeq ($(DISABLE_NSE_DX_DEPENDENT), TRUE)
-     	  DEFINES += -DNSE_DX_INDEPENDENT
-     endif
-     
      EXTERN_CORE += $(MICROPHYSICS_HOME)/nse_solver
      EXTERN_CORE += $(MICROPHYSICS_HOME)/util/hybrj
 endif

--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -3,3 +3,4 @@
 max_nse_iters        integer    500
 use_hybrid_solver    integer    1
 ase_tol              real       0.1_rt
+nse_dx_independent   bool       false

--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -3,4 +3,4 @@
 max_nse_iters        integer    500
 use_hybrid_solver    integer    1
 ase_tol              real       0.1_rt
-nse_dx_independent   bool       false
+nse_dx_independent   logical    .false.

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -61,7 +61,7 @@ void first_check_in_nse(T& state, const T& nse_state, bool& nse_check){
   // equilibrium condition: if pass proceed with ase if not proceed with regular eos integration
   // Eq. 14 in Kushnir paper
 
-  if (std::abs((r - r_nse) / r_nse) < 0.5){
+  if (std::abs((r - r_nse) / r_nse) < 0.5_rt){
     nse_check = true;
   }
   else{
@@ -532,9 +532,13 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 	// It didn't mention it in in the paragraph in section 4.4.3, but listed it in Eq. 12
 	// It didn't have a significant difference, but I'll leave it here for future reference
 
-	if ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
-	    || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s)
-	    // && ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
+	if (
+	    ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
+#ifndef NSE_DX_INDEPENDENT
+	    &&
+	    ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
+	     || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s))
+#endif	    
 	  ){
 
 	  // store nuclei index to fast_reaction if pass the condition
@@ -896,8 +900,12 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
   // to see whether the forward and balance rates are in equilibrium
   // see Eq. 17 again
 
-  if (scratch_t < ase_tol * t_s
-      && 2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol
+  if (
+      (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
+#ifndef NSE_DX_INDEPENDENT
+      &&
+      (scratch_t < ase_tol * t_s)
+#endif
       ){
 
     fastest_t = scratch_t;
@@ -990,7 +998,7 @@ bool in_nse(burn_t& state){
 
   bool nse_check = false;
 
-  if (state.T < 1.0e9_rt){
+  if (state.T < 2.0e9_rt){
     return nse_check;
   }
     
@@ -1066,7 +1074,6 @@ bool in_nse(burn_t& state){
     find_fast_reaction_cycle(n, Y, ydot, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
   }
 
-
   // Do nse grouping if found fast reaction cycle.
 
   // This holds group index for each nuclei
@@ -1086,14 +1093,11 @@ bool in_nse(burn_t& state){
     nse_grouping(group_ind, state, Y, rate_eval.screened_rates, t_s);
 
     // Check if we result in a single group after grouping
+    nse_check = false;
 
     if (in_single_group(group_ind)){
       nse_check = true;
     }
-    else{
-      nse_check = false;
-    }
-
   }
 
   return nse_check;

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -174,7 +174,6 @@ void get_rate_by_nuc(int& rate_index, amrex::Array1D<int, 1, 3> reactants_indice
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-			const amrex::Array1D<amrex::Real, 1, NumSpec+1>& ydot,
 			const amrex::Array1D<amrex::Real, 1, Rates::NumRates>& screened_rates,
 			const T& state, const amrex::Real& t_s, bool& found_fast_reaction_cycle){
 
@@ -740,7 +739,7 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
 		     const amrex::Array1D<amrex::Real, 1, NumSpec>& Y, const T& state,
 		     const amrex::Array1D<amrex::Real, 1, Rates::NumRates>& screened_rates,
 		     const amrex::Array1D<int, 1, NumSpec>& group_ind,
-		     const amrex::Real& t_s){
+		     const amrex::Real& t_s) {
 
   // This function determines whether current_rate has a faster timescale than
   // the provided time scale, current fastest_t.
@@ -1071,7 +1070,7 @@ bool in_nse(burn_t& state){
       break;
     }
 
-    find_fast_reaction_cycle(n, Y, ydot, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
+    find_fast_reaction_cycle(n, Y, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
   }
 
   // Do nse grouping if found fast reaction cycle.

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -533,11 +533,9 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 
 	if (
 	    ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
-#ifndef NSE_DX_INDEPENDENT
 	    &&
 	    ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
 	     || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s))
-#endif	    
 	  ){
 
 	  // store nuclei index to fast_reaction if pass the condition
@@ -899,13 +897,8 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
   // to see whether the forward and balance rates are in equilibrium
   // see Eq. 17 again
 
-  if (
-      (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
-#ifndef NSE_DX_INDEPENDENT
-      &&
-      (scratch_t < ase_tol * t_s)
-#endif
-      ){
+  if ( (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
+      && (scratch_t < ase_tol * t_s) ) {
 
     fastest_t = scratch_t;
 
@@ -1028,11 +1021,17 @@ bool in_nse(burn_t& state){
 
   eos_t eos_state;                             // need eos_state for speed of sound
 
-  // Here we need to find t_s, sound crossing timescale for a single zone
 
-  burn_to_eos<eos_t>(state, eos_state);
-  eos(eos_input_rt, eos_state);
-  amrex::Real t_s = state.dx / eos_state.cs;   // a parameter to characterize whether a rate is fast enough
+  // Initialize t_s, sound crossing timescale for a single zone to be max
+  amrex::Real t_s = std::numeric_limits<amrex::Real>::max();
+
+  // If we care about checking the timescale of the rate to be smaller than t_s, then:
+
+  if (!nse_dx_independent) {
+    burn_to_eos<eos_t>(state, eos_state);
+    eos(eos_input_rt, eos_state);
+    t_s = state.dx / eos_state.cs;   // a parameter to characterize whether a rate is fast enough
+  }
 
   // Find ydot
 

--- a/sphinx_docs/source/nse.rst
+++ b/sphinx_docs/source/nse.rst
@@ -257,7 +257,7 @@ There are 3 main criteria discussed in the :cite:`Kushnir_2020`.
      (\alpha, \gamma) \isotm{S}{32}
 
   The general approach to this is to start iterations from the heavy to the light nuclei to
-  use them as the starting point of the cycle. Then algorithmn checks if isotopes involved
+  use them as the starting point of the cycle. Then the algorithmn checks if isotopes involved
   in the network can actually form a cycle using the combination reactions above. If such cycle
   is formed, then we check the rates of these reactions to see if they satisfy the condition
   mention previously. If there are no isotope present in the network that would form
@@ -314,7 +314,18 @@ There are 3 main criteria discussed in the :cite:`Kushnir_2020`.
   when there is only a single group left, or there are two groups left where
   1 of them is the light-isotope-group.
 
+Additional Options
+------------------
 
+Here we have some runtime options to allow a more cruel estimation to the self-consistent
+nse check:
+
+* ``nse.nse_dx_independent = 1`` in the input file allows the nse check to ignore
+  the dependency on the cell size, ``dx``, which calculates the sound crossing time, ``t_s``.
+  Naturally, we require the timescale of the rates to be smaller than ``t_s`` to ensure the
+  states have time to achieve equilibrium. However, sometimes this check can be difficult
+  to acheive, so we leave this as an option for the user to explore.
+  
 .. rubric:: Footnotes
 
 .. [#fY] The table actually provides the weak rate, which is the sum


### PR DESCRIPTION
add an option to ignore the check where we want the time scale of the rates to be smaller than the sound crossing time scale.