### PR TITLE
add another option to use nse mass fractions for NSE_NET check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+# 23.03
+
+  * updated all of the pynucastro networks to the latest
+    pynucastro version (#1134, #1136)
+
+  * added tricubic interpolation for the NSE table (#1114)
+
+  * fixed an issue with rate tabulation in the aprox nets (#1123,
+    #1124)
+
+  * fixed some bugs in the NSE solver and made the hybrid Powell
+    solver more robust (#1122)
+
 # 23.02
 
   * `T_fixed` now works with NSE (#1098, #1111)

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -136,6 +136,10 @@ ifeq ($(USE_NSE_NET), TRUE)
      DEFINES += -DNSE_NET
      DEFINES += -DNSE
 
+     ifeq ($(DISABLE_NSE_DX_DEPENDENT), TRUE)
+     	  DEFINES += -DNSE_DX_INDEPENDENT
+     endif
+     
      EXTERN_CORE += $(MICROPHYSICS_HOME)/nse_solver
      EXTERN_CORE += $(MICROPHYSICS_HOME)/util/hybrj
 endif

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -136,10 +136,6 @@ ifeq ($(USE_NSE_NET), TRUE)
      DEFINES += -DNSE_NET
      DEFINES += -DNSE
 
-     ifeq ($(DISABLE_NSE_DX_DEPENDENT), TRUE)
-     	  DEFINES += -DNSE_DX_INDEPENDENT
-     endif
-     
      EXTERN_CORE += $(MICROPHYSICS_HOME)/nse_solver
      EXTERN_CORE += $(MICROPHYSICS_HOME)/util/hybrj
 endif

--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -3,3 +3,4 @@
 max_nse_iters        integer    500
 use_hybrid_solver    integer    1
 ase_tol              real       0.1_rt
+nse_dx_independent   bool       false

--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -1,6 +1,7 @@
 @namespace: nse
 
-max_nse_iters        integer    500
-use_hybrid_solver    integer    1
-ase_tol              real       0.1_rt
-nse_dx_independent   bool       false
+max_nse_iters           integer    500
+use_hybrid_solver       integer    1
+ase_tol                 real       0.1_rt
+nse_dx_independent      bool       false
+nse_molar_independent   bool       false

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -981,7 +981,7 @@ void nse_grouping(amrex::Array1D<int, 1, NumSpec>& group_ind, const T& state,
 
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-bool in_nse(burn_t& state){
+bool in_nse(burn_t& current_state){
 
   // This function returns the boolean that tells whether we're in nse or not
   // Note that it only works with pynucastro network for now.
@@ -990,18 +990,33 @@ bool in_nse(burn_t& state){
 
   bool nse_check = false;
 
-  if (state.T < 2.0e9_rt){
+  if (current_state.T < 2.0e9_rt){
     return nse_check;
   }
     
   // Get the nse state which is used to compare nse molar fractions.
-  const auto nse_state = get_actual_nse_state(state);
+
+  const auto nse_state = get_actual_nse_state(current_state, 1.0e-10_rt, true);
 
   // Check whether state is in the ballpark of NSE
 
-  first_check_in_nse(state, nse_state, nse_check);
-  if (!nse_check){
-    return nse_check;
+  // first_check_in_nse(current_state, nse_state, nse_check);
+  // if (!nse_check){
+  //   return nse_check;
+  // }
+
+  // We can do a further approximation where we use the NSE mass fractions
+  // instead of the current mass fractions. This makes the check soley dependent on
+  // the thermodynamic condition.
+  // Note we only do this after the first check, which should tell us whether
+  // our current mass fractions are in the ballpark of NSE mass fractions.
+
+  burn_t state = current_state;
+
+  if (nse_molar_independent) {
+    std::cout << "in here" << std::endl;
+    state = nse_state;
+    state.dx = current_state.dx;
   }
 
   // set molar fractions
@@ -1020,7 +1035,6 @@ bool in_nse(burn_t& state){
   evaluate_rates<do_T_derivatives, rate_t>(state, rate_eval);
 
   eos_t eos_state;                             // need eos_state for speed of sound
-
 
   // Initialize t_s, sound crossing timescale for a single zone to be max
   amrex::Real t_s = std::numeric_limits<amrex::Real>::max();

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -61,7 +61,7 @@ void first_check_in_nse(T& state, const T& nse_state, bool& nse_check){
   // equilibrium condition: if pass proceed with ase if not proceed with regular eos integration
   // Eq. 14 in Kushnir paper
 
-  if (std::abs((r - r_nse) / r_nse) < 0.5){
+  if (std::abs((r - r_nse) / r_nse) < 0.5_rt){
     nse_check = true;
   }
   else{
@@ -532,9 +532,13 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 	// It didn't mention it in in the paragraph in section 4.4.3, but listed it in Eq. 12
 	// It didn't have a significant difference, but I'll leave it here for future reference
 
-	if ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
-	    || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s)
-	    // && ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
+	if (
+	    ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
+#ifndef NSE_DX_INDEPENDENT
+	    &&
+	    ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
+	     || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s))
+#endif	    
 	  ){
 
 	  // store nuclei index to fast_reaction if pass the condition
@@ -896,8 +900,12 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
   // to see whether the forward and balance rates are in equilibrium
   // see Eq. 17 again
 
-  if (scratch_t < ase_tol * t_s
-      && 2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol
+  if (
+      (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
+#ifndef NSE_DX_INDEPENDENT
+      &&
+      (scratch_t < ase_tol * t_s)
+#endif
       ){
 
     fastest_t = scratch_t;
@@ -990,7 +998,7 @@ bool in_nse(burn_t& state){
 
   bool nse_check = false;
 
-  if (state.T < 1.0e9_rt){
+  if (state.T < 2.0e9_rt){
     return nse_check;
   }
     
@@ -1066,7 +1074,6 @@ bool in_nse(burn_t& state){
     find_fast_reaction_cycle(n, Y, ydot, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
   }
 
-
   // Do nse grouping if found fast reaction cycle.
 
   // This holds group index for each nuclei
@@ -1086,14 +1093,11 @@ bool in_nse(burn_t& state){
     nse_grouping(group_ind, state, Y, rate_eval.screened_rates, t_s);
 
     // Check if we result in a single group after grouping
+    nse_check = false;
 
     if (in_single_group(group_ind)){
       nse_check = true;
     }
-    else{
-      nse_check = false;
-    }
-
   }
 
   return nse_check;

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -996,7 +996,7 @@ bool in_nse(burn_t& current_state){
     
   // Get the nse state which is used to compare nse molar fractions.
 
-  const auto nse_state = get_actual_nse_state(current_state, 1.0e-10_rt, true);
+  const auto nse_state = get_actual_nse_state(current_state);
 
   // Check whether state is in the ballpark of NSE
 

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -22,7 +22,7 @@
 
 template<typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void first_check_in_nse(T& state, const T& nse_state, bool& nse_check){
+void check_nse_molar(T& state, const T& nse_state, bool& nse_check){
 
   // This function gives the first estimate whether we're in the nse or not
   // it checks whether the molar fractions of n,p,a are approximately in NSE
@@ -981,7 +981,7 @@ void nse_grouping(amrex::Array1D<int, 1, NumSpec>& group_ind, const T& state,
 
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-bool in_nse(burn_t& current_state){
+bool in_nse(burn_t& current_state) {
 
   // This function returns the boolean that tells whether we're in nse or not
   // Note that it only works with pynucastro network for now.
@@ -990,7 +990,7 @@ bool in_nse(burn_t& current_state){
 
   bool nse_check = false;
 
-  if (current_state.T < 2.0e9_rt){
+  if (current_state.T < 2.0e9_rt) {
     return nse_check;
   }
     
@@ -1000,10 +1000,10 @@ bool in_nse(burn_t& current_state){
 
   // Check whether state is in the ballpark of NSE
 
-  // first_check_in_nse(current_state, nse_state, nse_check);
-  // if (!nse_check){
-  //   return nse_check;
-  // }
+  check_nse_molar(current_state, nse_state, nse_check);
+  if (!nse_check) {
+    return nse_check;
+  }
 
   // We can do a further approximation where we use the NSE mass fractions
   // instead of the current mass fractions. This makes the check soley dependent on
@@ -1014,7 +1014,6 @@ bool in_nse(burn_t& current_state){
   burn_t state = current_state;
 
   if (nse_molar_independent) {
-    std::cout << "in here" << std::endl;
     state = nse_state;
     state.dx = current_state.dx;
   }

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -174,7 +174,6 @@ void get_rate_by_nuc(int& rate_index, amrex::Array1D<int, 1, 3> reactants_indice
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<amrex::Real, 1, NumSpec>& Y,
-			const amrex::Array1D<amrex::Real, 1, NumSpec+1>& ydot,
 			const amrex::Array1D<amrex::Real, 1, Rates::NumRates>& screened_rates,
 			const T& state, const amrex::Real& t_s, bool& found_fast_reaction_cycle){
 
@@ -740,7 +739,7 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
 		     const amrex::Array1D<amrex::Real, 1, NumSpec>& Y, const T& state,
 		     const amrex::Array1D<amrex::Real, 1, Rates::NumRates>& screened_rates,
 		     const amrex::Array1D<int, 1, NumSpec>& group_ind,
-		     const amrex::Real& t_s){
+		     const amrex::Real& t_s) {
 
   // This function determines whether current_rate has a faster timescale than
   // the provided time scale, current fastest_t.
@@ -1071,7 +1070,7 @@ bool in_nse(burn_t& state){
       break;
     }
 
-    find_fast_reaction_cycle(n, Y, ydot, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
+    find_fast_reaction_cycle(n, Y, rate_eval.screened_rates, state, t_s, found_fast_reaction_cycle);
   }
 
   // Do nse grouping if found fast reaction cycle.

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -533,11 +533,9 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 
 	if (
 	    ((2.0_rt * std::abs(b_f - b_r) / (b_f + b_r)) < ase_tol)
-#ifndef NSE_DX_INDEPENDENT
 	    &&
 	    ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
 	     || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s))
-#endif	    
 	  ){
 
 	  // store nuclei index to fast_reaction if pass the condition
@@ -899,13 +897,8 @@ void is_fastest_rate(amrex::Array1D<int, 1, 2>& merge_indices,
   // to see whether the forward and balance rates are in equilibrium
   // see Eq. 17 again
 
-  if (
-      (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
-#ifndef NSE_DX_INDEPENDENT
-      &&
-      (scratch_t < ase_tol * t_s)
-#endif
-      ){
+  if ( (2.0_rt * std::abs(b_f - b_r) / (b_f + b_r) < ase_tol)
+      && (scratch_t < ase_tol * t_s) ) {
 
     fastest_t = scratch_t;
 
@@ -1028,11 +1021,17 @@ bool in_nse(burn_t& state){
 
   eos_t eos_state;                             // need eos_state for speed of sound
 
-  // Here we need to find t_s, sound crossing timescale for a single zone
 
-  burn_to_eos<eos_t>(state, eos_state);
-  eos(eos_input_rt, eos_state);
-  amrex::Real t_s = state.dx / eos_state.cs;   // a parameter to characterize whether a rate is fast enough
+  // Initialize t_s, sound crossing timescale for a single zone to be max
+  amrex::Real t_s = std::numeric_limits<amrex::Real>::max();
+
+  // If we care about checking the timescale of the rate to be smaller than t_s, then:
+
+  if (!nse_dx_independent) {
+    burn_to_eos<eos_t>(state, eos_state);
+    eos(eos_input_rt, eos_state);
+    t_s = state.dx / eos_state.cs;   // a parameter to characterize whether a rate is fast enough
+  }
 
   // Find ydot
 

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -536,7 +536,7 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 	    &&
 	    ((Y_i(1) / amrex::min(b_f, b_r) < ase_tol * t_s)
 	     || (Y_i(2) / amrex::min(b_f, b_r) < ase_tol * t_s))
-	  ){
+	  ) {
 
 	  // store nuclei index to fast_reaction if pass the condition
 


### PR DESCRIPTION
Since forward and reverse rates depend on the mass fractions, to do a more cruel estimation, we can use nse mass fractions instead. This way, the thermodynamic condition becomes the only deciding factor.

Note here we still need to make sure the current mass fractions are not terribly away from the nse mass fractions, so only allow it after the first check, which checks on whether the current mass fractions are close to the nse mass fractions.