### PR TITLE
start of some clang-tidy fixes

### DIFF
--- a/EOS/breakout/actual_eos.H
+++ b/EOS/breakout/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>

--- a/EOS/eos_composition.H
+++ b/EOS/eos_composition.H
@@ -1,6 +1,5 @@
-
-#ifndef _eos_composition_H_
-#define _eos_composition_H_
+#ifndef EOS_COMPOSITION_H
+#define EOS_COMPOSITION_H
 
 #include <AMReX_BLFort.H>
 #include <network.H>

--- a/EOS/gamma_law/actual_eos.H
+++ b/EOS/gamma_law/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 #include <string>
 #include <extern_parameters.H>

--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 #include <string>
 #include <iostream>

--- a/EOS/multigamma/actual_eos.H
+++ b/EOS/multigamma/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 // This is a multi-gamma EOS.  Each species can have its own gamma, but
 // otherwise, they all act as an ideal gas.

--- a/EOS/multigamma/eos_composition.H
+++ b/EOS/multigamma/eos_composition.H
@@ -1,6 +1,5 @@
-
-#ifndef _eos_composition_H_
-#define _eos_composition_H_
+#ifndef EOS_COMPOSITION_H
+#define EOS_COMPOSITION_H
 
 #include <AMReX_BLFort.H>
 #include <network.H>

--- a/EOS/polytrope/actual_eos.H
+++ b/EOS/polytrope/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 // This is the equation of state for a polytropic fluid:
 // P = K rho^gamma

--- a/EOS/primordial_chem/actual_eos.H
+++ b/EOS/primordial_chem/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 // This is a mult-gamma EOS for primordial ISM chemistry.
 // Each species can have its own gamma, but

--- a/EOS/primordial_chem/eos_composition.H
+++ b/EOS/primordial_chem/eos_composition.H
@@ -1,6 +1,5 @@
-
-#ifndef _eos_composition_H_
-#define _eos_composition_H_
+#ifndef EOS_COMPOSITION_H
+#define EOS_COMPOSITION_H
 
 #include <AMReX_BLFort.H>
 #include <network.H>

--- a/EOS/rad_power_law/actual_eos.H
+++ b/EOS/rad_power_law/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 // This is an artificial equation of state used primarily for radiation tests.
 //

--- a/EOS/tillotson/actual_eos.H
+++ b/EOS/tillotson/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 #include <string>
 #include <extern_parameters.H>

--- a/EOS/ztwd/actual_eos.H
+++ b/EOS/ztwd/actual_eos.H
@@ -1,5 +1,5 @@
-#ifndef _actual_eos_H_
-#define _actual_eos_H_
+#ifndef ACTUAL_EOS_H
+#define ACTUAL_EOS_H
 
 // This is the equation of state for zero-temperature white dwarf 
 // matter composed of degenerate electrons:

--- a/conductivity/constant/actual_conductivity.H
+++ b/conductivity/constant/actual_conductivity.H
@@ -1,5 +1,5 @@
-#ifndef _actual_conductivity_H_
-#define _actual_conductivity_H_
+#ifndef ACTUAL_CONDUCTIVITY_H
+#define ACTUAL_CONDUCTIVITY_H
 
 #include <cmath>
 #include <eos_type.H>

--- a/conductivity/constant_opacity/actual_conductivity.H
+++ b/conductivity/constant_opacity/actual_conductivity.H
@@ -1,5 +1,5 @@
-#ifndef _actual_conductivity_H_
-#define _actual_conductivity_H_
+#ifndef ACTUAL_CONDUCTIVITY_H
+#define ACTUAL_CONDUCTIVITY_H
 
 #include <cmath>
 #include <eos_type.H>

--- a/conductivity/powerlaw/actual_conductivity.H
+++ b/conductivity/powerlaw/actual_conductivity.H
@@ -1,5 +1,5 @@
-#ifndef _actual_conductivity_H_
-#define _actual_conductivity_H_
+#ifndef ACTUAL_CONDUCTIVITY_H
+#define ACTUAL_CONDUCTIVITY_H
 
 #include <cmath>
 #include <eos_type.H>

--- a/conductivity/stellar/actual_conductivity.H
+++ b/conductivity/stellar/actual_conductivity.H
@@ -1,5 +1,5 @@
-#ifndef _actual_conductivity_H_
-#define _actual_conductivity_H_
+#ifndef ACTUAL_CONDUCTIVITY_H
+#define ACTUAL_CONDUCTIVITY_H
 
 #include <cmath>
 #include <eos_type.H>

--- a/constants/fundamental_constants.H
+++ b/constants/fundamental_constants.H
@@ -1,7 +1,7 @@
-// Fundamental constants taken from NIST's 2010 CODATA recommended values
+#ifndef FUNDAMENTAL_CONSTANTS_H
+#define FUNDAMENTAL_CONSTANTS_H
 
-#ifndef _fundamental_constants_H_
-#define _fundamental_constants_H_
+// Fundamental constants taken from NIST's 2010 CODATA recommended values
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>

--- a/integration/BackwardEuler/be_type.H
+++ b/integration/BackwardEuler/be_type.H
@@ -1,5 +1,5 @@
-#ifndef _be_type_H_
-#define _be_type_H_
+#ifndef BE_TYPE_H
+#define BE_TYPE_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>

--- a/integration/VODE/vode_dvhin.H
+++ b/integration/VODE/vode_dvhin.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvhin_H_
-#define _vode_dvhin_H_
+#ifndef VODE_DVHIN_H
+#define VODE_DVHIN_H
 
 #ifdef STRANG
 #include <integrator_rhs_strang.H>

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvjac_H_
-#define _vode_dvjac_H_
+#ifndef VODE_DVJAC_H
+#define VODE_DVJAC_H
 
 #include <vode_type.H>
 #ifndef NEW_NETWORK_IMPLEMENTATION

--- a/integration/VODE/vode_dvjust.H
+++ b/integration/VODE/vode_dvjust.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvjust_H_
-#define _vode_dvjust_H_
+#ifndef VODE_DVJUST_H
+#define VODE_DVJUST_H
 
 #include <vode_type.H>
 

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvnlsd_H_
-#define _vode_dvnlsd_H_
+#ifndef VODE_DVNLSD_H
+#define VODE_DVNLSD_H
 
 #include <vode_type.H>
 #ifndef NEW_NETWORK_IMPLEMENTATION

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvode_H_
-#define _vode_dvode_H_
+#ifndef VODE_DVODE_H
+#define VODE_DVODE_H
 
 #include <vode_type.H>
 #include <vode_dvhin.H>

--- a/integration/VODE/vode_dvset.H
+++ b/integration/VODE/vode_dvset.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvset_H_
-#define _vode_dvset_H_
+#ifndef VODE_DVSET_H
+#define VODE_DVSET_H
 
 #include <vode_type.H>
 

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -1,5 +1,5 @@
-#ifndef _vode_dvstep_H_
-#define _vode_dvstep_H_
+#ifndef VODE_DVSTEP_H
+#define VODE_DVSTEP_H
 
 #include <vode_type.H>
 #include <vode_dvset.H>

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -1,5 +1,5 @@
-#ifndef _vode_type_H_
-#define _vode_type_H_
+#ifndef VODE_TYPE_H
+#define VODE_TYPE_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>

--- a/integration/integrator.H
+++ b/integration/integrator.H
@@ -1,5 +1,5 @@
-#ifndef _integrator_H_
-#define _integrator_H_
+#ifndef INTEGRATOR_H
+#define INTEGRATOR_H
 
 #ifdef SIMPLIFIED_SDC
 #include <actual_integrator_simplified_sdc.H>

--- a/integration/integrator_rhs_strang.H
+++ b/integration/integrator_rhs_strang.H
@@ -1,5 +1,5 @@
-#ifndef _integrator_rhs_strang_H_
-#define _integrator_rhs_strang_H_
+#ifndef INTEGRATOR_RHS_STRANG_H
+#define INTEGRATOR_RHS_STRANG_H
 
 #include <network.H>
 #include <actual_network.H>

--- a/interfaces/ArrayUtilities.H
+++ b/interfaces/ArrayUtilities.H
@@ -1,5 +1,5 @@
-#ifndef _array_utilities_H_
-#define _array_utilities_H_
+#ifndef ARRAY_UTILITIES_H
+#define ARRAY_UTILITIES_H
 
 #include <AMReX_Array.H>
 #include <AMReX_REAL.H>

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -1,5 +1,5 @@
-#ifndef _burn_type_H_
-#define _burn_type_H_
+#ifndef BURN_TYPE_H
+#define BURN_TYPE_H
 
 #include <iomanip>
 

--- a/interfaces/burner.H
+++ b/interfaces/burner.H
@@ -1,5 +1,5 @@
-#ifndef _burner_H_
-#define _burner_H_
+#ifndef BURNER_H
+#define BURNER_H
 
 #include <burn_type.H>
 #include <integrator.H>

--- a/interfaces/conductivity.H
+++ b/interfaces/conductivity.H
@@ -1,5 +1,5 @@
-#ifndef _conductivity_H_
-#define _conductivity_H_
+#ifndef CONDUCTIVITY_H
+#define CONDUCTIVITY_H
 
 #include <eos_type.H>
 #include <actual_conductivity.H>

--- a/interfaces/eos.H
+++ b/interfaces/eos.H
@@ -1,5 +1,5 @@
-#ifndef _eos_H_
-#define _eos_H_
+#ifndef EOS_H
+#define EOS_H
 
 #include <network_properties.H>
 #include <eos_data.H>

--- a/interfaces/eos_data.H
+++ b/interfaces/eos_data.H
@@ -1,5 +1,5 @@
-#ifndef _eos_data_H_
-#define _eos_data_H_
+#ifndef EOS_DATA_H
+#define EOS_DATA_H
 
 #include <AMReX.H>
 #include <AMReX_REAL.H>

--- a/interfaces/eos_override.H
+++ b/interfaces/eos_override.H
@@ -1,5 +1,5 @@
-#ifndef _eos_override_H_
-#define _eos_override_H_
+#ifndef EOS_OVERRIDE_H
+#define EOS_OVERRIDE_H
 
 #include <eos_type.H>
 

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -1,5 +1,5 @@
-#ifndef _eos_type_H_
-#define _eos_type_H_
+#ifndef EOS_TYPE_H
+#define EOS_TYPE_H
 
 #include <AMReX.H>
 #include <network.H>

--- a/interfaces/network.H
+++ b/interfaces/network.H
@@ -1,12 +1,12 @@
-#ifndef _network_H_
-#define _network_H_
+#ifndef NETWORK_H
+#define NETWORK_H
 
 #include <string>
 #include <network_properties.H>
 
 void network_init();
 
-AMREX_INLINE int network_spec_index(const std::string name) {
+AMREX_INLINE int network_spec_index(const std::string& name) {
   int idx = -1;
   for (int n = 0; n < NumSpec; n++) {
     if (name == spec_names_cxx[n]) {
@@ -18,7 +18,7 @@ AMREX_INLINE int network_spec_index(const std::string name) {
 }
 
 #if NAUX_NET > 0
-AMREX_INLINE int network_aux_index(const std::string name) {
+AMREX_INLINE int network_aux_index(const std::string& name) {
   int idx = -1;
   for (int n = 0; n < NumAux; n++) {
     if (name == aux_names_cxx[n]) {

--- a/interfaces/tfactors.H
+++ b/interfaces/tfactors.H
@@ -1,5 +1,5 @@
-#ifndef _tfactors_H_
-#define _tfactors_H_
+#ifndef TFACTORS_H
+#define TFACTORS_H
 
 #include <AMReX.H>
 #include <cmath>

--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -1,5 +1,5 @@
-#ifndef _actual_network_H_
-#define _actual_network_H_
+#ifndef ACTUAL_NETWORK_H
+#define ACTUAL_NETWORK_H
 
 #define NEW_NETWORK_IMPLEMENTATION
 

--- a/networks/general_null/network_header.template
+++ b/networks/general_null/network_header.template
@@ -6,8 +6,8 @@
 #include <AMReX_BLFort.H>
 #include <AMReX_Array.H>
 
-#ifndef _network_properties_H_
-#define _network_properties_H_
+#ifndef NETWORK_PROPERTIES_H
+#define NETWORK_PROPERTIES_H
 
 #if defined(__GNUC__)
 #define MICROPHYSICS_UNUSED [[gnu::unused]]

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -1,5 +1,5 @@
-#ifndef _actual_network_H_
-#define _actual_network_H_
+#ifndef ACTUAL_NETWORK_H
+#define ACTUAL_NETWORK_H
 
 #define NEW_NETWORK_IMPLEMENTATION
 

--- a/networks/powerlaw/actual_network.H
+++ b/networks/powerlaw/actual_network.H
@@ -1,5 +1,5 @@
-#ifndef _actual_network_H_
-#define _actual_network_H_
+#ifndef ACTUAL_NETWORK_H
+#define ACTUAL_NETWORK_H
 
 void actual_network_init();
 

--- a/networks/powerlaw/actual_rhs.H
+++ b/networks/powerlaw/actual_rhs.H
@@ -1,5 +1,5 @@
-#ifndef _actual_rhs_H_
-#define _actual_rhs_H_
+#ifndef ACTUAL_RHS_H
+#define ACTUAL_RHS_H
 
 #include <cmath>
 

--- a/networks/rate_type.H
+++ b/networks/rate_type.H
@@ -1,5 +1,5 @@
-#ifndef _rate_type_H_
-#define _rate_type_H_
+#ifndef RATE_TYPE_H
+#define RATE_TYPE_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>

--- a/neutrinos/sneut5.H
+++ b/neutrinos/sneut5.H
@@ -1,5 +1,5 @@
-#ifndef _sneut5_H_
-#define _sneut5_H_
+#ifndef SNEUT5_H
+#define SNEUT5_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>

--- a/rates/aprox_rates.H
+++ b/rates/aprox_rates.H
@@ -1,5 +1,5 @@
-#ifndef _aprox_rates_H_
-#define _aprox_rates_H_
+#ifndef APROX_RATES_H
+#define APROX_RATES_H
 
 #include <aprox_rates_data.H>
 #include <tfactors.H>

--- a/rates/aprox_rates_data.H
+++ b/rates/aprox_rates_data.H
@@ -1,5 +1,5 @@
-#ifndef _aprox_rates_data_H_
-#define _aprox_rates_data_H_
+#ifndef APROX_RATES_DATA_H
+#define APROX_RATES_DATA_H
 
 #include <AMReX.H>
 #include <AMReX_Array.H>

--- a/screening/screen.H
+++ b/screening/screen.H
@@ -1,5 +1,5 @@
-#ifndef _screen_H_
-#define _screen_H_
+#ifndef SCREEN_H
+#define SCREEN_H
 
 #include <AMReX.H>
 #include <AMReX_Algorithm.H>

--- a/unit_test/test_aprox_rates/variables.H
+++ b/unit_test/test_aprox_rates/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/test_conductivity/variables.H
+++ b/unit_test/test_conductivity/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/test_eos/variables.H
+++ b/unit_test/test_eos/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/test_jac/jac_zones.H
+++ b/unit_test/test_jac/jac_zones.H
@@ -1,5 +1,5 @@
-#ifndef _react_zones_H_
-#define _react_zones_H_
+#ifndef REACT_ZONES_H
+#define REACT_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_jac/jac_zones.H
+++ b/unit_test/test_jac/jac_zones.H
@@ -1,5 +1,5 @@
-#ifndef REACT_ZONES_H
-#define REACT_ZONES_H
+#ifndef JAC_ZONES_H
+#define JAC_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_jac/variables.H
+++ b/unit_test/test_jac/variables.H
@@ -1,5 +1,5 @@
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 // A module to provide integer indices into the various storage arrays
 // for accessing the different variables by name.

--- a/unit_test/test_react/react_zones.H
+++ b/unit_test/test_react/react_zones.H
@@ -1,5 +1,5 @@
-#ifndef _react_zones_H_
-#define _react_zones_H_
+#ifndef REACT_ZONES_H
+#define REACT_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_react/variables.H
+++ b/unit_test/test_react/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/test_rhs/rhs_zones.H
+++ b/unit_test/test_rhs/rhs_zones.H
@@ -1,5 +1,5 @@
-#ifndef _react_zones_H_
-#define _react_zones_H_
+#ifndef REACT_ZONES_H
+#define REACT_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_rhs/rhs_zones.H
+++ b/unit_test/test_rhs/rhs_zones.H
@@ -1,5 +1,5 @@
-#ifndef REACT_ZONES_H
-#define REACT_ZONES_H
+#ifndef RHS_ZONES_H
+#define RHS_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_rhs/variables.H
+++ b/unit_test/test_rhs/variables.H
@@ -1,5 +1,5 @@
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 // A module to provide integer indices into the various storage arrays
 // for accessing the different variables by name.

--- a/unit_test/test_screening/variables.H
+++ b/unit_test/test_screening/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/test_sdc/react_zones.H
+++ b/unit_test/test_sdc/react_zones.H
@@ -1,5 +1,5 @@
-#ifndef _react_zones_H_
-#define _react_zones_H_
+#ifndef REACT_ZONES_H
+#define REACT_ZONES_H
 
 #include <variables.H>
 #include <network.H>

--- a/unit_test/test_sdc/variables.H
+++ b/unit_test/test_sdc/variables.H
@@ -1,8 +1,8 @@
 #include <vector>
 #include <string>
 
-#ifndef _variables_H_
-#define _variables_H_
+#ifndef VARIABLES_H
+#define VARIABLES_H
 
 #include <AMReX_Vector.H>
 

--- a/unit_test/write_job_info.cpp
+++ b/unit_test/write_job_info.cpp
@@ -46,7 +46,7 @@ void write_job_info(const std::string& dir) {
   jobInfoFile << " Plotfile Information\n";
   jobInfoFile << PrettyLine;
 
-  time_t now = time(0);
+  time_t now = time(nullptr);
 
   // Convert now to tm struct for local timezone
   tm* localtm = localtime(&now);

--- a/util/build_scripts/write_probin.py
+++ b/util/build_scripts/write_probin.py
@@ -39,8 +39,8 @@ HEADER = """
 """
 
 CXX_HEADER = """
-#ifndef _external_parameters_H_
-#define _external_parameters_H_
+#ifndef EXTERNAL_PARAMETERS_H
+#define EXTERNAL_PARAMETERS_H
 #include <AMReX_BLFort.H>
 #include <AMReX_REAL.H>
 

--- a/util/esum.H
+++ b/util/esum.H
@@ -27,8 +27,8 @@
 // other than msum that do exact arithmetic, without
 // changing the interface as seen in the networks.
 
-#ifndef _esum_H_
-#define _esum_H_
+#ifndef ESUM_H
+#define ESUM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>

--- a/util/esum_cxx.py
+++ b/util/esum_cxx.py
@@ -33,8 +33,8 @@ module_start = """
 // other than msum that do exact arithmetic, without
 // changing the interface as seen in the networks.
 
-#ifndef _esum_H_
-#define _esum_H_
+#ifndef ESUM_H
+#define ESUM_H
 
 #include <AMReX_REAL.H>
 #include <AMReX_Array.H>


### PR DESCRIPTION
mostly updates header guards to conform to our standards and not conflict with reserved patterns