### PR TITLE
if the integrator said we entered NSE, then continue

### DIFF
--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -272,6 +272,7 @@ int dvode (burn_t& state, dvode_t& vstate)
            if (in_nse(state)) {
                istate = -100;
                vstate.t = vstate.tn;
+               state.nse = true;
                return istate;
            }
        }

--- a/interfaces/burner.H
+++ b/interfaces/burner.H
@@ -61,11 +61,16 @@ void burner (burn_t& state, Real dt)
 
         // we use a relaxed NSE criteria now to catch states that are
         // right on the edge of being in NSE
+
+        bool entered_nse = state.nse;
+
 #ifdef NSE_TABLE
-        if (in_nse(state, true) && state.success == false && dt_remaining > 0.0) {
+        auto redo_nse = in_nse(state, true);
 #else
-	if (in_nse(state, nse_skip_molar) && state.success == false && dt_remaining > 0.0) {
+        auto redo_nse = in_nse(state, nse_skip_molar);
 #endif
+
+        if ((redo_nse || entered_nse) && state.success == false && dt_remaining > 0.0) {
 
 #ifndef AMREX_USE_GPU
             std::cout << "recovering burn failure in NSE, zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;


### PR DESCRIPTION
previously we would recompute in_nse() and use that, but sometimes the integrator is exploring a state and enters NSE while the check in the burner does not.  This happens even with the requirement that we integrator for 10 steps before following NSE.  Now we will always enter NSE if the integrator said we did