### PR TITLE
Make sure generated code is identical between make runs and fix CI failure

### DIFF
--- a/Make.Microphysics
+++ b/Make.Microphysics
@@ -196,6 +196,7 @@ $(objEXETempDir)/AMReX_buildInfo.o: .FORCE
           --link_flags "$(LDFLAGS)" --libraries "$(libraries)" \
           --MODULES "$(MNAMES)" $(EXTRA_BUILD_INFO) \
           --GIT "$(TOP) $(AMREX_HOME) $(MICROPHYSICS_HOME)"
+	@if [ ! -d $(objEXETempDir) ]; then mkdir -p $(objEXETempDir); fi
 	$(SILENT) $(CCACHE) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c $(CXXEXEFLAGS) AMReX_buildInfo.cpp -o $(objEXETempDir)/AMReX_buildInfo.o
 	$(SILENT) $(RM) AMReX_buildInfo.cpp
 

--- a/util/build_scripts/write_probin.py
+++ b/util/build_scripts/write_probin.py
@@ -214,7 +214,7 @@ def write_probin(probin_template, param_files,
 
         namespaces = {q.namespace for q in params}
 
-        for nm in namespaces:
+        for nm in sorted(namespaces):
             params_nm = [q for q in params if q.namespace == nm]
 
             # open namespace


### PR DESCRIPTION
This fixes cache misses when using ccache and a race condition that was causing intermittent CI failures