### PR TITLE
fix primordial_chem CI

### DIFF
--- a/.github/workflows/burn_cell_primordial_chem.yml
+++ b/.github/workflows/burn_cell_primordial_chem.yml
@@ -26,7 +26,9 @@ jobs:
           sudo apt-get update -y -qq
           sudo apt-get -qq -y install curl cmake jq clang g++>=9.3.0
 
-      - name: Compile
+      - name: Compile and run
         run: |
           cd unit_test/burn_cell_primordial_chem
           make -j 2
+	  ./main1d.gnu.DEBUG.ex inputs_primordial_chem
+

--- a/.github/workflows/burn_cell_primordial_chem.yml
+++ b/.github/workflows/burn_cell_primordial_chem.yml
@@ -30,5 +30,5 @@ jobs:
         run: |
           cd unit_test/burn_cell_primordial_chem
           make -j 2
-	  ./main1d.gnu.DEBUG.ex inputs_primordial_chem
+          ./main1d.gnu.DEBUG.ex inputs_primordial_chem
 

--- a/.github/workflows/cmake_build_cell_primordial_chem.yml
+++ b/.github/workflows/cmake_build_cell_primordial_chem.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Compile and run
         run: |
-	  mkdir build && cd build
-	  cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMREX=true
-	  ninja
-          
+          mkdir build && cd build
+          cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMREX=true
+          ninja
+
 

--- a/.github/workflows/cmake_build_cell_primordial_chem.yml
+++ b/.github/workflows/cmake_build_cell_primordial_chem.yml
@@ -1,0 +1,35 @@
+name: cmake_burn_cell_primordial_chem
+
+on: [pull_request]
+jobs:
+  burn_cell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get AMReX
+        run: |
+          mkdir external
+          cd external
+          git clone https://github.com/AMReX-Codes/amrex.git
+          cd amrex
+          git checkout development
+          echo 'AMREX_HOME=$(GITHUB_WORKSPACE)/external/amrex' >> $GITHUB_ENV
+          echo $AMREX_HOME
+          if [[ -n "${AMREX_HOME}" ]]; then exit 1; fi
+          cd ../..
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get -qq -y install curl cmake jq clang g++>=9.3.0
+
+      - name: Compile and run
+        run: |
+	  mkdir build && cd build
+	  cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMREX=true
+	  ninja
+          
+


### PR DESCRIPTION
This runs the burn_cell_primordial chem unit test and should fail if the test does not pass. Previously, we were only building the test, not actually running it.

*TODO*: we still need to make sure that `burn_cell_primordial_chem` returns a non-zero exit code from the process if VODE fails or the results don't match expectations.