### PR TITLE
Use redshift as a runtime parameter in primordial chem

### DIFF
--- a/networks/primordial_chem/_parameters
+++ b/networks/primordial_chem/_parameters
@@ -3,3 +3,5 @@
 
 # cutoff for species mass fractions
 small_x                              real               1.e-100
+# assumed redshift for primordial chem (Pop III star formation)
+pc_redshift                          real               30e0

--- a/networks/primordial_chem/_parameters
+++ b/networks/primordial_chem/_parameters
@@ -4,4 +4,4 @@
 # cutoff for species mass fractions
 small_x                              real               1.e-100
 # assumed redshift for primordial chem (Pop III star formation)
-pc_redshift                          real               30e0
+redshift                          real               30e0

--- a/networks/primordial_chem/actual_rhs.H
+++ b/networks/primordial_chem/actual_rhs.H
@@ -1184,7 +1184,7 @@ Real rhs_eint(const burn_t& state,
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 {
-    Real z = pc_redshift;
+    Real z = redshift;
 
     Array1D<Real, 0, NumSpec-1> X;
     for (int i = 0; i < NumSpec; ++i) {
@@ -6652,7 +6652,7 @@ template<class MatrixType>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_jac(const burn_t& state, MatrixType& jac)
 {
-    Real z = pc_redshift;
+    Real z = redshift;
 
     Array1D<Real, 0, NumSpec-1> X;
     for (int i = 0; i < NumSpec; ++i) {

--- a/networks/primordial_chem/actual_rhs.H
+++ b/networks/primordial_chem/actual_rhs.H
@@ -1184,7 +1184,7 @@ Real rhs_eint(const burn_t& state,
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_rhs (burn_t& state, Array1D<Real, 1, neqs>& ydot)
 {
-    Real z = 30.;
+    Real z = pc_redshift;
 
     Array1D<Real, 0, NumSpec-1> X;
     for (int i = 0; i < NumSpec; ++i) {
@@ -6652,7 +6652,7 @@ template<class MatrixType>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_jac(const burn_t& state, MatrixType& jac)
 {
-    Real const z = 30.;
+    Real z = pc_redshift;
 
     Array1D<Real, 0, NumSpec-1> X;
     for (int i = 0; i < NumSpec; ++i) {

--- a/unit_test/burn_cell_primordial_chem/burn_cell.H
+++ b/unit_test/burn_cell_primordial_chem/burn_cell.H
@@ -169,7 +169,7 @@ void burn_cell_c()
         break; }
 
         // stop the test if we have reached very high densities
-        if (dd > 3e-6) {
+        if (dd > 2e-6) {
         break; }
 
         std::cout<<"step "<<n<<" done"<<std::endl;

--- a/unit_test/burn_cell_primordial_chem/inputs_primordial_chem
+++ b/unit_test/burn_cell_primordial_chem/inputs_primordial_chem
@@ -50,7 +50,11 @@ integrator.renormalize_abundances = 0
 integrator.rtol_spec = 1.0e-4
 integrator.atol_spec = 1.0e-4
 
+#assumed redshift for Pop III star formation
+network.pc_redshift = 30.0
+
 # amrex runtime parameters
 # these params help debug the code
 #amrex.throw_exception = 1
 #amrex.signal_handling = 0
+

--- a/unit_test/burn_cell_primordial_chem/inputs_primordial_chem
+++ b/unit_test/burn_cell_primordial_chem/inputs_primordial_chem
@@ -51,7 +51,7 @@ integrator.rtol_spec = 1.0e-4
 integrator.atol_spec = 1.0e-4
 
 #assumed redshift for Pop III star formation
-network.pc_redshift = 30.0
+network.redshift = 30.0
 
 # amrex runtime parameters
 # these params help debug the code


### PR DESCRIPTION
We have to assume a certain redshift for doing Pop III simulations with primordial chemistry. We use z = 30, but it is also common to use a value between z = 20-30. With this PR, the user can define the redshift they want as a runtime parameter.

@zingale - I don't think Microphysics already has a redshift parameter embedded somewhere, right? 