### PR TITLE
Template VODE on number of integrator equations

### DIFF
--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -20,9 +20,9 @@ template <typename BurnT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void actual_integrator (BurnT& state, Real dt)
 {
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
-    dvode_t<neqs> vode_state{};
+    dvode_t<int_neqs> vode_state{};
 
     // Set the tolerances.
 

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -20,7 +20,9 @@ template <typename BurnT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void actual_integrator (BurnT& state, Real dt)
 {
-    dvode_t vode_state{};
+    constexpr int neqs = integrator_neqs<BurnT>();
+
+    dvode_t<neqs> vode_state{};
 
     // Set the tolerances.
 

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -20,8 +20,9 @@ template <typename BurnT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void actual_integrator (BurnT& state, Real dt)
 {
+    constexpr int neqs = integrator_neqs<BurnT>();
 
-    dvode_t vode_state{};
+    dvode_t<neqs> vode_state{};
 
     // set the Jacobian type
     vode_state.jacobian_type = jacobian;

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -20,9 +20,9 @@ template <typename BurnT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void actual_integrator (BurnT& state, Real dt)
 {
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
-    dvode_t<neqs> vode_state{};
+    dvode_t<int_neqs> vode_state{};
 
     // set the Jacobian type
     vode_state.jacobian_type = jacobian;

--- a/integration/VODE/vode_dvhin.H
+++ b/integration/VODE/vode_dvhin.H
@@ -24,7 +24,7 @@ void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
     // A bias factor of 1/2 is applied to the resulting h.
     // The sign of H0 is inferred from the initial values of tout and T0.
 
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     const Real PT1 = 0.1e0_rt;
 
@@ -45,7 +45,7 @@ void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
     Real HUB = PT1 * TDIST;
 
 #ifdef TRUE_SDC
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         Real atol;
         if (i == 1) {
             atol = vstate.atol_dens;
@@ -62,7 +62,7 @@ void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
     }
 
 #else
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         Real atol = i <= NumSpec ? vstate.atol_spec : vstate.atol_enuc;
         Real DELYI = PT1 * std::abs(vstate.yh(i,1)) + atol;
         Real AFI = std::abs(vstate.yh(i,2));
@@ -91,7 +91,7 @@ void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
 
             // Estimate the second derivative as a difference quotient in f.
             Real H = std::copysign(HG, vstate.tout - vstate.t);
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.y(i) = vstate.yh(i,1) + H * vstate.yh(i,2);
             }
 
@@ -99,15 +99,15 @@ void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
 
             rhs(t1, state, vstate, vstate.acor);
 
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.acor(i) = (vstate.acor(i) - vstate.yh(i,2)) / H;
             }
 
             Real YDDNRM = 0.0_rt;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 YDDNRM += (vstate.acor(i) * vstate.ewt(i)) * (vstate.acor(i) * vstate.ewt(i));
             }
-            YDDNRM = std::sqrt(YDDNRM / neqs);
+            YDDNRM = std::sqrt(YDDNRM / int_neqs);
 
             // Get the corresponding new value of h.
             if (YDDNRM * HUB * HUB > 2.0_rt) {

--- a/integration/VODE/vode_dvhin.H
+++ b/integration/VODE/vode_dvhin.H
@@ -11,9 +11,9 @@
 #include <vode_rhs_true_sdc.H>
 #endif
 
-template <typename BurnT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
+void dvhin (BurnT& state, DvodeT& vstate, Real& H0, int& NITER, int& IER)
 {
     // This routine computes the step size, H0, to be attempted on the
     // first step, when the user has not supplied a value for this.
@@ -23,6 +23,8 @@ void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
     // and this is used to define h from w.r.m.s.norm(h**2 * yddot / 2) = 1.
     // A bias factor of 1/2 is applied to the resulting h.
     // The sign of H0 is inferred from the initial values of tout and T0.
+
+    constexpr int neqs = integrator_neqs<BurnT>();
 
     const Real PT1 = 0.1e0_rt;
 
@@ -43,7 +45,7 @@ void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
     Real HUB = PT1 * TDIST;
 
 #ifdef TRUE_SDC
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         Real atol;
         if (i == 1) {
             atol = vstate.atol_dens;
@@ -60,7 +62,7 @@ void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
     }
 
 #else
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         Real atol = i <= NumSpec ? vstate.atol_spec : vstate.atol_enuc;
         Real DELYI = PT1 * std::abs(vstate.yh(i,1)) + atol;
         Real AFI = std::abs(vstate.yh(i,2));
@@ -89,7 +91,7 @@ void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
 
             // Estimate the second derivative as a difference quotient in f.
             Real H = std::copysign(HG, vstate.tout - vstate.t);
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.y(i) = vstate.yh(i,1) + H * vstate.yh(i,2);
             }
 
@@ -97,15 +99,15 @@ void dvhin (BurnT& state, dvode_t& vstate, Real& H0, int& NITER, int& IER)
 
             rhs(t1, state, vstate, vstate.acor);
 
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.acor(i) = (vstate.acor(i) - vstate.yh(i,2)) / H;
             }
 
             Real YDDNRM = 0.0_rt;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 YDDNRM += (vstate.acor(i) * vstate.ewt(i)) * (vstate.acor(i) * vstate.ewt(i));
             }
-            YDDNRM = std::sqrt(YDDNRM / INT_NEQS);
+            YDDNRM = std::sqrt(YDDNRM / neqs);
 
             // Get the corresponding new value of h.
             if (YDDNRM * HUB * HUB > 2.0_rt) {

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -26,7 +26,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
     // in preparation for later solution of linear systems with P as
     // coefficient matrix. This is done by DGEFA.
 
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     IERPJ = 0;
 
@@ -109,18 +109,18 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
             vstate.JCUR = 1;
 
             Real fac = 0.0_rt;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 fac += (vstate.savf(i) * vstate.ewt(i)) * (vstate.savf(i) * vstate.ewt(i));
             }
-            fac = std::sqrt(fac / neqs);
+            fac = std::sqrt(fac / int_neqs);
 
-            Real R0 = 1000.0_rt * std::abs(vstate.H) * UROUND * neqs * fac;
+            Real R0 = 1000.0_rt * std::abs(vstate.H) * UROUND * int_neqs * fac;
             if (R0 == 0.0_rt) {
                 R0 = 1.0_rt;
             }
 
             bool in_jacobian = true;
-            for (int j = 1; j <= neqs; ++j) {
+            for (int j = 1; j <= int_neqs; ++j) {
                 Real yj = vstate.y(j);
 
                 Real R = amrex::max(std::sqrt(UROUND) * std::abs(yj), R0 / vstate.ewt(j));
@@ -128,7 +128,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
                 fac = 1.0_rt / R;
 
                 rhs(vstate.tn, state, vstate, vstate.acor, in_jacobian);
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.jac.set(i, j, (vstate.acor(i) - vstate.savf(i)) * fac);
                 }
 
@@ -136,7 +136,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
             }
 
             // Increment the RHS evaluation counter by N.
-            vstate.NFE += neqs;
+            vstate.NFE += int_neqs;
 
 #ifdef ALLOW_JACOBIAN_CACHING
             // Store the Jacobian if we're caching.
@@ -176,7 +176,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
     RHS::dgefa(vstate.jac);
     IER = 0;
 #else
-    dgefa<neqs>(vstate.jac, pivot, IER);
+    dgefa<int_neqs>(vstate.jac, pivot, IER);
 #endif
 
     if (IER != 0) {

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -15,17 +15,18 @@
 #include <vode_rhs_true_sdc.H>
 #endif
 
-template <typename BurnT>
+template <typename IArray1D, typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, dvode_t& vstate)
+void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, DvodeT& vstate)
 {
-
     // dvjac is called by dvnlsd to compute and process the matrix
     // P = I - h*rl1*J , where J is an approximation to the Jacobian
     // that we obtain either through direct evaluation or caching from
     // a previous evaluation. P is then subjected to LU decomposition
     // in preparation for later solution of linear systems with P as
     // coefficient matrix. This is done by DGEFA.
+
+    constexpr int neqs = integrator_neqs<BurnT>();
 
     IERPJ = 0;
 
@@ -108,18 +109,18 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, dvode_t& vstate)
             vstate.JCUR = 1;
 
             Real fac = 0.0_rt;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 fac += (vstate.savf(i) * vstate.ewt(i)) * (vstate.savf(i) * vstate.ewt(i));
             }
-            fac = std::sqrt(fac / INT_NEQS);
+            fac = std::sqrt(fac / neqs);
 
-            Real R0 = 1000.0_rt * std::abs(vstate.H) * UROUND * INT_NEQS * fac;
+            Real R0 = 1000.0_rt * std::abs(vstate.H) * UROUND * neqs * fac;
             if (R0 == 0.0_rt) {
                 R0 = 1.0_rt;
             }
 
             bool in_jacobian = true;
-            for (int j = 1; j <= INT_NEQS; ++j) {
+            for (int j = 1; j <= neqs; ++j) {
                 Real yj = vstate.y(j);
 
                 Real R = amrex::max(std::sqrt(UROUND) * std::abs(yj), R0 / vstate.ewt(j));
@@ -127,7 +128,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, dvode_t& vstate)
                 fac = 1.0_rt / R;
 
                 rhs(vstate.tn, state, vstate, vstate.acor, in_jacobian);
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.jac.set(i, j, (vstate.acor(i) - vstate.savf(i)) * fac);
                 }
 
@@ -135,7 +136,7 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, dvode_t& vstate)
             }
 
             // Increment the RHS evaluation counter by N.
-            vstate.NFE += INT_NEQS;
+            vstate.NFE += neqs;
 
 #ifdef ALLOW_JACOBIAN_CACHING
             // Store the Jacobian if we're caching.
@@ -175,13 +176,12 @@ void dvjac (IArray1D& pivot, int& IERPJ, BurnT& state, dvode_t& vstate)
     RHS::dgefa(vstate.jac);
     IER = 0;
 #else
-    dgefa<INT_NEQS>(vstate.jac, pivot, IER);
+    dgefa<neqs>(vstate.jac, pivot, IER);
 #endif
 
     if (IER != 0) {
         IERPJ = 1;
     }
-
 }
 
 #endif

--- a/integration/VODE/vode_dvjust.H
+++ b/integration/VODE/vode_dvjust.H
@@ -13,7 +13,7 @@ void dvjust (int IORD, DvodeT& vstate)
     //  IORD  = An integer flag used to indicate an order
     //          increase (IORD = +1) or an order decrease (IORD = -1).
 
-    constexpr int neqs = vstate.NEQS;
+    constexpr int int_neqs = vstate.NEQS;
 
     if ((vstate.NQ == 2) && (IORD != 1)) {
         return;
@@ -46,7 +46,7 @@ void dvjust (int IORD, DvodeT& vstate)
 
         // Subtract correction terms from YH array.
         for (int j = 3; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.yh(i,j) -= vstate.yh(i,vstate.L) * vstate.el(j);
             }
         }
@@ -84,13 +84,13 @@ void dvjust (int IORD, DvodeT& vstate)
 
         T1 = (-ALPH0 - ALPH1) / PROD;
         // Load column L + 1 in YH array.
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             vstate.yh(i,vstate.L+1) = T1 * vstate.yh(i,VODE_LMAX);
         }
 
         // Add correction terms to YH array.
         for (int j = 3; j <= vstate.NQ + 1; ++j) {
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.yh(i,j) += vstate.el(j) * vstate.yh(i,vstate.L+1);
             }
         }

--- a/integration/VODE/vode_dvjust.H
+++ b/integration/VODE/vode_dvjust.H
@@ -3,15 +3,17 @@
 
 #include <vode_type.H>
 
+template <typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dvjust (int IORD, dvode_t& vstate)
+void dvjust (int IORD, DvodeT& vstate)
 {
-
     // This subroutine adjusts the YH array on reduction of order,
     // and also when the order is increased.
 
     //  IORD  = An integer flag used to indicate an order
     //          increase (IORD = +1) or an order decrease (IORD = -1).
+
+    constexpr int neqs = vstate.NEQS;
 
     if ((vstate.NQ == 2) && (IORD != 1)) {
         return;
@@ -44,7 +46,7 @@ void dvjust (int IORD, dvode_t& vstate)
 
         // Subtract correction terms from YH array.
         for (int j = 3; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.yh(i,j) -= vstate.yh(i,vstate.L) * vstate.el(j);
             }
         }
@@ -82,19 +84,18 @@ void dvjust (int IORD, dvode_t& vstate)
 
         T1 = (-ALPH0 - ALPH1) / PROD;
         // Load column L + 1 in YH array.
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             vstate.yh(i,vstate.L+1) = T1 * vstate.yh(i,VODE_LMAX);
         }
 
         // Add correction terms to YH array.
         for (int j = 3; j <= vstate.NQ + 1; ++j) {
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.yh(i,j) += vstate.el(j) * vstate.yh(i,vstate.L+1);
             }
         }
 
     }
-
 }
 
 #endif

--- a/integration/VODE/vode_dvjust.H
+++ b/integration/VODE/vode_dvjust.H
@@ -3,9 +3,9 @@
 
 #include <vode_type.H>
 
-template <typename DvodeT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dvjust (int IORD, DvodeT& vstate)
+void dvjust (int IORD, BurnT& state, DvodeT& vstate)
 {
     // This subroutine adjusts the YH array on reduction of order,
     // and also when the order is increased.
@@ -13,7 +13,7 @@ void dvjust (int IORD, DvodeT& vstate)
     //  IORD  = An integer flag used to indicate an order
     //          increase (IORD = +1) or an order decrease (IORD = -1).
 
-    constexpr int int_neqs = vstate.NEQS;
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     if ((vstate.NQ == 2) && (IORD != 1)) {
         return;

--- a/integration/VODE/vode_dvjust.H
+++ b/integration/VODE/vode_dvjust.H
@@ -7,6 +7,8 @@ template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void dvjust (int IORD, BurnT& state, DvodeT& vstate)
 {
+    amrex::ignore_unused(state);
+
     // This subroutine adjusts the YH array on reduction of order,
     // and also when the order is increased.
 

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -11,7 +11,7 @@ template <typename IArray1D, typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
 {
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     Real ACNRM = 1.e10_rt;
 
@@ -62,7 +62,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
         M = 0;
         Real DELP = 0.0_rt;
 
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             vstate.y(i) = vstate.yh(i,1);
         }
 
@@ -93,7 +93,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
 
         }
 
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             vstate.acor(i) = 0.0_rt;
         }
 
@@ -106,7 +106,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
             // correction is scaled by the factor 2/(1+RC) to account for
             // changes in h*rl1 since the last dvjac call.
 
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.y(i) = (vstate.RL1 * vstate.H) * vstate.savf(i) -
                               (vstate.RL1 * vstate.yh(i,2) + vstate.acor(i));
             }
@@ -114,27 +114,27 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
 #ifdef NEW_NETWORK_IMPLEMENTATION
             RHS::dgesl(vstate.jac, vstate.y);
 #else
-            dgesl<neqs>(vstate.jac, pivot, vstate.y);
+            dgesl<int_neqs>(vstate.jac, pivot, vstate.y);
 #endif
 
             if (vstate.RC != 1.0_rt) {
                 Real CSCALE = 2.0_rt / (1.0_rt + vstate.RC);
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.y(i) *= CSCALE;
                 }
             }
 
             DEL = 0.0_rt;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 DEL += (vstate.y(i) * vstate.ewt(i)) * (vstate.y(i) * vstate.ewt(i));
             }
-            DEL = std::sqrt(DEL / neqs);
+            DEL = std::sqrt(DEL / int_neqs);
 
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.acor(i) += vstate.y(i);
             }
 
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.y(i) = vstate.yh(i,1) + vstate.acor(i);
             }
 
@@ -195,10 +195,10 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
 
     if (M > 0) {
         ACNRM = 0.0_rt;
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             ACNRM += (vstate.acor(i) * vstate.ewt(i)) * (vstate.acor(i) * vstate.ewt(i));
         }
-        ACNRM = std::sqrt(ACNRM / neqs);
+        ACNRM = std::sqrt(ACNRM / int_neqs);
     }
 
     return ACNRM;

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -7,10 +7,11 @@
 #endif
 #include <vode_dvjac.H>
 
-template <typename BurnT>
+template <typename IArray1D, typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
+Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, DvodeT& vstate)
 {
+    constexpr int neqs = integrator_neqs<BurnT>();
 
     Real ACNRM = 1.e10_rt;
 
@@ -61,7 +62,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
         M = 0;
         Real DELP = 0.0_rt;
 
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             vstate.y(i) = vstate.yh(i,1);
         }
 
@@ -92,7 +93,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
 
         }
 
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             vstate.acor(i) = 0.0_rt;
         }
 
@@ -105,7 +106,7 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
             // correction is scaled by the factor 2/(1+RC) to account for
             // changes in h*rl1 since the last dvjac call.
 
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.y(i) = (vstate.RL1 * vstate.H) * vstate.savf(i) -
                               (vstate.RL1 * vstate.yh(i,2) + vstate.acor(i));
             }
@@ -113,27 +114,27 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
 #ifdef NEW_NETWORK_IMPLEMENTATION
             RHS::dgesl(vstate.jac, vstate.y);
 #else
-            dgesl<INT_NEQS>(vstate.jac, pivot, vstate.y);
+            dgesl<neqs>(vstate.jac, pivot, vstate.y);
 #endif
 
             if (vstate.RC != 1.0_rt) {
                 Real CSCALE = 2.0_rt / (1.0_rt + vstate.RC);
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.y(i) *= CSCALE;
                 }
             }
 
             DEL = 0.0_rt;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 DEL += (vstate.y(i) * vstate.ewt(i)) * (vstate.y(i) * vstate.ewt(i));
             }
-            DEL = std::sqrt(DEL / INT_NEQS);
+            DEL = std::sqrt(DEL / neqs);
 
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.acor(i) += vstate.y(i);
             }
 
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.y(i) = vstate.yh(i,1) + vstate.acor(i);
             }
 
@@ -194,14 +195,13 @@ Real dvnlsd (IArray1D& pivot, int& NFLAG, BurnT& state, dvode_t& vstate)
 
     if (M > 0) {
         ACNRM = 0.0_rt;
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             ACNRM += (vstate.acor(i) * vstate.ewt(i)) * (vstate.acor(i) * vstate.ewt(i));
         }
-        ACNRM = std::sqrt(ACNRM / INT_NEQS);
+        ACNRM = std::sqrt(ACNRM / neqs);
     }
 
     return ACNRM;
-
 }
 
 #endif

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -24,7 +24,7 @@ template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 int dvode (BurnT& state, DvodeT& vstate)
 {
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     // Local variables
     Real H0, S;
@@ -52,11 +52,11 @@ int dvode (BurnT& state, DvodeT& vstate)
 
     // Initial call to the RHS.
 
-    Array1D<Real, 1, neqs> f_init;
+    Array1D<Real, 1, int_neqs> f_init;
 
     rhs(vstate.t, state, vstate, f_init);
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         vstate.yh(i,2) = f_init(i);
     }
 
@@ -64,7 +64,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 
     // Load the initial value array in yh.
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         vstate.yh(i,1) = vstate.y(i);
     }
 
@@ -106,7 +106,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 
     // Load H with H0 and scale yh(:,2) by H0.
     vstate.H = H0;
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         vstate.yh(i,2) *= H0;
     }
 
@@ -147,7 +147,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 #ifndef AMREX_USE_GPU
                std::cout << Font::Bold << FGColor::Red << "DVODE: maximum number of steps taken before reaching TOUT" << ResetDisplay << std::endl;
 #endif
-               for (int i = 1; i <= neqs; ++i) {
+               for (int i = 1; i <= int_neqs; ++i) {
                    vstate.y(i) = vstate.yh(i,1);
                }
 
@@ -183,10 +183,10 @@ int dvode (BurnT& state, DvodeT& vstate)
        }
 
        Real TOLSF = 0.0_rt;
-       for (int i = 1; i <= neqs; ++i) {
+       for (int i = 1; i <= int_neqs; ++i) {
            TOLSF += (vstate.yh(i,1) * vstate.ewt(i)) * (vstate.yh(i,1) * vstate.ewt(i));
        }
-       TOLSF = UROUND * std::sqrt(TOLSF / neqs);
+       TOLSF = UROUND * std::sqrt(TOLSF / int_neqs);
 
        if (TOLSF > 1.0_rt) {
 
@@ -202,7 +202,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 #ifndef AMREX_USE_GPU
            std::cout << "DVODE: too much accuracy requested" << std::endl;
 #endif
-           for (int i = 1; i <= neqs; ++i) {
+           for (int i = 1; i <= int_neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -224,7 +224,7 @@ int dvode (BurnT& state, DvodeT& vstate)
            std::cout << Font::Bold << FGColor::Red << "DVODE: error test failed repeatedly or with abs(H) = HMIN" << ResetDisplay << std::endl;
 #endif
            // Set Y array, T, and optional output.
-           for (int i = 1; i <= neqs; ++i) {
+           for (int i = 1; i <= int_neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -240,7 +240,7 @@ int dvode (BurnT& state, DvodeT& vstate)
            std::cout << Font::Bold << FGColor::Red << "DVODE: corrector convergence failed repeatedly or with abs(H) = HMIN" << ResetDisplay << std::endl;
 #endif
            // Set Y array, T, and optional output.
-           for (int i = 1; i <= neqs; ++i) {
+           for (int i = 1; i <= int_neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -287,7 +287,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 
        // If TOUT has been reached, interpolate.
 
-       for (int i = 1; i <= neqs; ++i) {
+       for (int i = 1; i <= int_neqs; ++i) {
            vstate.y(i) = vstate.yh(i,vstate.L);
        }
 
@@ -295,7 +295,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 
        for (int jb = 1; jb <= vstate.NQ; ++jb) {
            int j = vstate.NQ - jb;
-           for (int i = 1; i <= neqs; ++i) {
+           for (int i = 1; i <= int_neqs; ++i) {
                vstate.y(i) = vstate.yh(i,j+1) + S * vstate.y(i);
            }
        }

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -20,10 +20,11 @@
 #include <nse_check.H>
 #endif
 
-template <typename BurnT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int dvode (BurnT& state, dvode_t& vstate)
+int dvode (BurnT& state, DvodeT& vstate)
 {
+    constexpr int neqs = integrator_neqs<BurnT>();
 
     // Local variables
     Real H0, S;
@@ -51,11 +52,11 @@ int dvode (BurnT& state, dvode_t& vstate)
 
     // Initial call to the RHS.
 
-    Array1D<Real, 1, INT_NEQS> f_init;
+    Array1D<Real, 1, neqs> f_init;
 
     rhs(vstate.t, state, vstate, f_init);
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         vstate.yh(i,2) = f_init(i);
     }
 
@@ -63,7 +64,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 
     // Load the initial value array in yh.
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         vstate.yh(i,1) = vstate.y(i);
     }
 
@@ -105,7 +106,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 
     // Load H with H0 and scale yh(:,2) by H0.
     vstate.H = H0;
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         vstate.yh(i,2) *= H0;
     }
 
@@ -146,7 +147,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 #ifndef AMREX_USE_GPU
                std::cout << Font::Bold << FGColor::Red << "DVODE: maximum number of steps taken before reaching TOUT" << ResetDisplay << std::endl;
 #endif
-               for (int i = 1; i <= INT_NEQS; ++i) {
+               for (int i = 1; i <= neqs; ++i) {
                    vstate.y(i) = vstate.yh(i,1);
                }
 
@@ -182,10 +183,10 @@ int dvode (BurnT& state, dvode_t& vstate)
        }
 
        Real TOLSF = 0.0_rt;
-       for (int i = 1; i <= INT_NEQS; ++i) {
+       for (int i = 1; i <= neqs; ++i) {
            TOLSF += (vstate.yh(i,1) * vstate.ewt(i)) * (vstate.yh(i,1) * vstate.ewt(i));
        }
-       TOLSF = UROUND * std::sqrt(TOLSF / INT_NEQS);
+       TOLSF = UROUND * std::sqrt(TOLSF / neqs);
 
        if (TOLSF > 1.0_rt) {
 
@@ -201,7 +202,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 #ifndef AMREX_USE_GPU
            std::cout << "DVODE: too much accuracy requested" << std::endl;
 #endif
-           for (int i = 1; i <= INT_NEQS; ++i) {
+           for (int i = 1; i <= neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -223,7 +224,7 @@ int dvode (BurnT& state, dvode_t& vstate)
            std::cout << Font::Bold << FGColor::Red << "DVODE: error test failed repeatedly or with abs(H) = HMIN" << ResetDisplay << std::endl;
 #endif
            // Set Y array, T, and optional output.
-           for (int i = 1; i <= INT_NEQS; ++i) {
+           for (int i = 1; i <= neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -239,7 +240,7 @@ int dvode (BurnT& state, dvode_t& vstate)
            std::cout << Font::Bold << FGColor::Red << "DVODE: corrector convergence failed repeatedly or with abs(H) = HMIN" << ResetDisplay << std::endl;
 #endif
            // Set Y array, T, and optional output.
-           for (int i = 1; i <= INT_NEQS; ++i) {
+           for (int i = 1; i <= neqs; ++i) {
                vstate.y(i) = vstate.yh(i,1);
            }
 
@@ -286,7 +287,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 
        // If TOUT has been reached, interpolate.
 
-       for (int i = 1; i <= INT_NEQS; ++i) {
+       for (int i = 1; i <= neqs; ++i) {
            vstate.y(i) = vstate.yh(i,vstate.L);
        }
 
@@ -294,7 +295,7 @@ int dvode (BurnT& state, dvode_t& vstate)
 
        for (int jb = 1; jb <= vstate.NQ; ++jb) {
            int j = vstate.NQ - jb;
-           for (int i = 1; i <= INT_NEQS; ++i) {
+           for (int i = 1; i <= neqs; ++i) {
                vstate.y(i) = vstate.yh(i,j+1) + S * vstate.y(i);
            }
        }
@@ -305,7 +306,6 @@ int dvode (BurnT& state, dvode_t& vstate)
        return istate;
 
     }
-
 }
 
 #endif

--- a/integration/VODE/vode_dvset.H
+++ b/integration/VODE/vode_dvset.H
@@ -3,10 +3,10 @@
 
 #include <vode_type.H>
 
+template<typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void dvset (dvode_t& vstate)
+void dvset (DvodeT& vstate)
 {
-
     // dvset is called by dvstep and sets coefficients for use there.
     //
     // For each order NQ, the coefficients in EL are calculated by use of
@@ -81,7 +81,6 @@ void dvset (dvode_t& vstate)
     }
 
     vstate.tq(4) = CORTES * vstate.tq(2);
-
 }
 
 #endif

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -13,11 +13,11 @@ void advance_nordsieck (DvodeT& vstate)
     // Effectively multiplies the Nordsieck history
     // array by the Pascal triangle matrix.
 
-    constexpr int neqs = vstate.NEQS;
+    constexpr int int_neqs = vstate.NEQS;
 
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.yh(i,j) += vstate.yh(i,j+1);
             }
         }
@@ -32,11 +32,11 @@ void retract_nordsieck (DvodeT& vstate)
     // Undoes the Pascal triangle matrix multiplication
     // implemented in subroutine advance_nordsieck.
 
-    constexpr int neqs = vstate.NEQS;
+    constexpr int int_neqs = vstate.NEQS;
 
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.yh(i,j) -= vstate.yh(i,j+1);
             }
         }
@@ -82,7 +82,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
     Real FLOTL, R;
     int NCF, NFLAG;
 
-    constexpr int neqs = integrator_neqs<BurnT>();
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     int kflag = 0;
     TOLD = vstate.tn;
@@ -117,7 +117,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
         for (int j = 2; j <= vstate.L; ++j) {
             R *= vstate.ETA;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.yh(i,j) *= R;
             }
         }
@@ -128,7 +128,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
     }
 
-    Array1D<short, 1, neqs> pivot;
+    Array1D<short, 1, int_neqs> pivot;
 
     // Compute the predicted values by effectively
     // multiplying the yh array by the Pascal triangle matrix.
@@ -139,15 +139,15 @@ int dvstep (BurnT& state, DvodeT& vstate)
     // We will use this saved value to determine if any
     // constraints were violated in the update.
 
-    Array1D<Real, 1, neqs> y_save;
+    Array1D<Real, 1, int_neqs> y_save;
 #ifdef STRANG
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         y_save(i) = vstate.y(i);
     }
 #endif
 #ifdef SIMPLIFIED_SDC
     Real rho_old = state.rho_orig + TOLD * state.ydot_a[SRHO];
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         y_save(i) = vstate.y(i);
     }
     for (int i = 1; i <= NumSpec; ++i) {
@@ -203,7 +203,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -339,14 +339,14 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
             vstate.tau(1) = vstate.H;
             for (int j = 1; j <= vstate.L; ++j) {
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,j) += vstate.el(j) * vstate.acor(i);
                 }
             }
 
             vstate.NQWAIT -= 1;
             if ((vstate.L != VODE_LMAX) && (vstate.NQWAIT == 1)) {
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,VODE_LMAX) = vstate.acor(i);
                 }
                 vstate.CONP = vstate.tq(5);
@@ -369,7 +369,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             }
 
             R = 1.0_rt / vstate.tq(2);
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.acor(i) *= R;
             }
 
@@ -412,7 +412,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -449,7 +449,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -468,7 +468,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
         vstate.tau(1) = vstate.H;
         rhs(vstate.tn, state, vstate, vstate.savf);
         vstate.NFE += 1;
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             vstate.yh(i,2) = vstate.H * vstate.savf(i);
         }
 
@@ -498,10 +498,10 @@ int dvstep (BurnT& state, DvodeT& vstate)
         if (vstate.NQ != 1) {
             // Compute ratio of new H to current H at the current order less one.
             DDN = 0.0_rt;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 DDN += (vstate.yh(i,vstate.L) * vstate.ewt(i)) * (vstate.yh(i,vstate.L) * vstate.ewt(i));
             }
-            DDN = std::sqrt(DDN / neqs) / vstate.tq(1);
+            DDN = std::sqrt(DDN / int_neqs) / vstate.tq(1);
             ETAQM1 = 1.0_rt / (std::pow(BIAS1 * DDN, 1.0_rt / (FLOTL - 1.0_rt)) + ADDON);
         }
 
@@ -510,14 +510,14 @@ int dvstep (BurnT& state, DvodeT& vstate)
         if (vstate.L != VODE_LMAX) {
             // Compute ratio of new H to current H at current order plus one.
             CNQUOT = (vstate.tq(5) / vstate.CONP) * std::pow(vstate.H / vstate.tau(2), vstate.L);
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 vstate.savf(i) = vstate.acor(i) - CNQUOT * vstate.yh(i,VODE_LMAX);
             }
             DUP = 0.0_rt;
-            for (int i = 1; i <= neqs; ++i) {
+            for (int i = 1; i <= int_neqs; ++i) {
                 DUP += (vstate.savf(i) * vstate.ewt(i)) * (vstate.savf(i) * vstate.ewt(i));
             }
-            DUP = std::sqrt(DUP / neqs) / vstate.tq(3);
+            DUP = std::sqrt(DUP / int_neqs) / vstate.tq(3);
             ETAQP1 = 1.0_rt / (std::pow(BIAS3 * DUP, 1.0_rt / (FLOTL + 1.0_rt)) + ADDON);
         }
 
@@ -525,7 +525,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             if (ETAQP1 > ETAQM1) {
                 vstate.ETA = ETAQP1;
                 vstate.NEWQ = static_cast<short>(vstate.NQ + 1);
-                for (int i = 1; i <= neqs; ++i) {
+                for (int i = 1; i <= int_neqs; ++i) {
                     vstate.yh(i,VODE_LMAX) = vstate.acor(i);
                 }
             }
@@ -559,7 +559,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             vstate.ETAMAX = ETAMX2;
         }
         R = 1.0_rt / vstate.tq(2);
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             vstate.acor(i) *= R;
         }
         return kflag;
@@ -573,7 +573,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
         vstate.ETAMAX = ETAMX2;
     }
     R = 1.0_rt / vstate.tq(2);
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         vstate.acor(i) *= R;
     }
 

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -10,6 +10,8 @@ template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void advance_nordsieck (BurnT& state, DvodeT& vstate)
 {
+    amrex::ignore_unused(state);
+
     // Effectively multiplies the Nordsieck history
     // array by the Pascal triangle matrix.
 
@@ -29,6 +31,8 @@ template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void retract_nordsieck (BurnT& state, DvodeT& vstate)
 {
+    amrex::ignore_unused(state);
+
     // Undoes the Pascal triangle matrix multiplication
     // implemented in subroutine advance_nordsieck.
 

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -6,47 +6,48 @@
 #include <vode_dvjust.H>
 #include <vode_dvnlsd.H>
 
+template<typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void advance_nordsieck (dvode_t& vstate)
+void advance_nordsieck (DvodeT& vstate)
 {
-
     // Effectively multiplies the Nordsieck history
     // array by the Pascal triangle matrix.
 
+    constexpr int neqs = vstate.NEQS;
+
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.yh(i,j) += vstate.yh(i,j+1);
             }
         }
     }
-
 }
 
 
+template<typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void retract_nordsieck (dvode_t& vstate)
+void retract_nordsieck (DvodeT& vstate)
 {
-
     // Undoes the Pascal triangle matrix multiplication
     // implemented in subroutine advance_nordsieck.
 
+    constexpr int neqs = vstate.NEQS;
+
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.yh(i,j) -= vstate.yh(i,j+1);
             }
         }
     }
-
 }
 
 
-template <typename BurnT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-int dvstep (BurnT& state, dvode_t& vstate)
+int dvstep (BurnT& state, DvodeT& vstate)
 {
-
     // dvstep performs one step of the integration of an initial value
     // problem for a system of ordinary differential equations.
     // dvstep calls subroutine dvnlsd for the solution of the nonlinear system
@@ -81,6 +82,8 @@ int dvstep (BurnT& state, dvode_t& vstate)
     Real FLOTL, R;
     int NCF, NFLAG;
 
+    constexpr int neqs = integrator_neqs<BurnT>();
+
     int kflag = 0;
     TOLD = vstate.tn;
     NCF = 0;
@@ -114,7 +117,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
         for (int j = 2; j <= vstate.L; ++j) {
             R *= vstate.ETA;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.yh(i,j) *= R;
             }
         }
@@ -125,7 +128,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
     }
 
-    IArray1D pivot;
+    Array1D<short, 1, neqs> pivot;
 
     // Compute the predicted values by effectively
     // multiplying the yh array by the Pascal triangle matrix.
@@ -136,15 +139,15 @@ int dvstep (BurnT& state, dvode_t& vstate)
     // We will use this saved value to determine if any
     // constraints were violated in the update.
 
-    Array1D<Real, 1, INT_NEQS> y_save;
+    Array1D<Real, 1, neqs> y_save;
 #ifdef STRANG
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         y_save(i) = vstate.y(i);
     }
 #endif
 #ifdef SIMPLIFIED_SDC
     Real rho_old = state.rho_orig + TOLD * state.ydot_a[SRHO];
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         y_save(i) = vstate.y(i);
     }
     for (int i = 1; i <= NumSpec; ++i) {
@@ -200,7 +203,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -336,14 +339,14 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
             vstate.tau(1) = vstate.H;
             for (int j = 1; j <= vstate.L; ++j) {
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,j) += vstate.el(j) * vstate.acor(i);
                 }
             }
 
             vstate.NQWAIT -= 1;
             if ((vstate.L != VODE_LMAX) && (vstate.NQWAIT == 1)) {
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,VODE_LMAX) = vstate.acor(i);
                 }
                 vstate.CONP = vstate.tq(5);
@@ -366,7 +369,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
             }
 
             R = 1.0_rt / vstate.tq(2);
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.acor(i) *= R;
             }
 
@@ -409,7 +412,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -446,7 +449,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
 
             for (int j = 2; j <= vstate.L; ++j) {
                 R *= vstate.ETA;
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,j) *= R;
                 }
             }
@@ -465,7 +468,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
         vstate.tau(1) = vstate.H;
         rhs(vstate.tn, state, vstate, vstate.savf);
         vstate.NFE += 1;
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             vstate.yh(i,2) = vstate.H * vstate.savf(i);
         }
 
@@ -495,10 +498,10 @@ int dvstep (BurnT& state, dvode_t& vstate)
         if (vstate.NQ != 1) {
             // Compute ratio of new H to current H at the current order less one.
             DDN = 0.0_rt;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 DDN += (vstate.yh(i,vstate.L) * vstate.ewt(i)) * (vstate.yh(i,vstate.L) * vstate.ewt(i));
             }
-            DDN = std::sqrt(DDN / INT_NEQS) / vstate.tq(1);
+            DDN = std::sqrt(DDN / neqs) / vstate.tq(1);
             ETAQM1 = 1.0_rt / (std::pow(BIAS1 * DDN, 1.0_rt / (FLOTL - 1.0_rt)) + ADDON);
         }
 
@@ -507,14 +510,14 @@ int dvstep (BurnT& state, dvode_t& vstate)
         if (vstate.L != VODE_LMAX) {
             // Compute ratio of new H to current H at current order plus one.
             CNQUOT = (vstate.tq(5) / vstate.CONP) * std::pow(vstate.H / vstate.tau(2), vstate.L);
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 vstate.savf(i) = vstate.acor(i) - CNQUOT * vstate.yh(i,VODE_LMAX);
             }
             DUP = 0.0_rt;
-            for (int i = 1; i <= INT_NEQS; ++i) {
+            for (int i = 1; i <= neqs; ++i) {
                 DUP += (vstate.savf(i) * vstate.ewt(i)) * (vstate.savf(i) * vstate.ewt(i));
             }
-            DUP = std::sqrt(DUP / INT_NEQS) / vstate.tq(3);
+            DUP = std::sqrt(DUP / neqs) / vstate.tq(3);
             ETAQP1 = 1.0_rt / (std::pow(BIAS3 * DUP, 1.0_rt / (FLOTL + 1.0_rt)) + ADDON);
         }
 
@@ -522,7 +525,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
             if (ETAQP1 > ETAQM1) {
                 vstate.ETA = ETAQP1;
                 vstate.NEWQ = static_cast<short>(vstate.NQ + 1);
-                for (int i = 1; i <= INT_NEQS; ++i) {
+                for (int i = 1; i <= neqs; ++i) {
                     vstate.yh(i,VODE_LMAX) = vstate.acor(i);
                 }
             }
@@ -556,7 +559,7 @@ int dvstep (BurnT& state, dvode_t& vstate)
             vstate.ETAMAX = ETAMX2;
         }
         R = 1.0_rt / vstate.tq(2);
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             vstate.acor(i) *= R;
         }
         return kflag;
@@ -570,12 +573,11 @@ int dvstep (BurnT& state, dvode_t& vstate)
         vstate.ETAMAX = ETAMX2;
     }
     R = 1.0_rt / vstate.tq(2);
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         vstate.acor(i) *= R;
     }
 
     return kflag;
-
 }
 
 #endif

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -6,14 +6,14 @@
 #include <vode_dvjust.H>
 #include <vode_dvnlsd.H>
 
-template<typename DvodeT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void advance_nordsieck (DvodeT& vstate)
+void advance_nordsieck (BurnT& state, DvodeT& vstate)
 {
     // Effectively multiplies the Nordsieck history
     // array by the Pascal triangle matrix.
 
-    constexpr int int_neqs = vstate.NEQS;
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
@@ -25,14 +25,14 @@ void advance_nordsieck (DvodeT& vstate)
 }
 
 
-template<typename DvodeT>
+template <typename BurnT, typename DvodeT>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void retract_nordsieck (DvodeT& vstate)
+void retract_nordsieck (BurnT& state, DvodeT& vstate)
 {
     // Undoes the Pascal triangle matrix multiplication
     // implemented in subroutine advance_nordsieck.
 
-    constexpr int int_neqs = vstate.NEQS;
+    constexpr int int_neqs = integrator_neqs<BurnT>();
 
     for (int k = vstate.NQ; k >= 1; --k) {
         for (int j = k; j <= vstate.NQ; ++j) {
@@ -99,13 +99,13 @@ int dvstep (BurnT& state, DvodeT& vstate)
     if (vstate.NEWH != 0) {
 
         if (vstate.NEWQ < vstate.NQ) {
-            dvjust(-1, vstate);
+            dvjust(-1, state, vstate);
             vstate.NQ = vstate.NEWQ;
             vstate.L = static_cast<short>(vstate.NQ + 1);
             vstate.NQWAIT = vstate.L;
         }
         else if (vstate.NEWQ > vstate.NQ) {
-            dvjust(1, vstate);
+            dvjust(1, state, vstate);
             vstate.NQ = vstate.NEWQ;
             vstate.L = static_cast<short>(vstate.NQ + 1);
             vstate.NQWAIT = vstate.L;
@@ -159,7 +159,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
         vstate.tn += vstate.H;
 
-        advance_nordsieck(vstate);
+        advance_nordsieck(state, vstate);
 
         dvset(vstate);
 
@@ -183,7 +183,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             vstate.ETAMAX = 1.0_rt;
             vstate.tn = TOLD;
 
-            retract_nordsieck(vstate);
+            retract_nordsieck(state, vstate);
 
             if (std::abs(vstate.H) <= HMIN * ONEPSM) {
                 kflag = -2;
@@ -388,7 +388,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
         NFLAG = -2;
         vstate.tn = TOLD;
 
-        retract_nordsieck(vstate);
+        retract_nordsieck(state, vstate);
 
         if (std::abs(vstate.H) <= HMIN * ONEPSM) {
             kflag = -1;
@@ -439,7 +439,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
 
         if (vstate.NQ != 1) {
             vstate.ETA = amrex::max(ETAMIN, HMIN / std::abs(vstate.H));
-            dvjust(-1, vstate);
+            dvjust(-1, state, vstate);
             vstate.L = vstate.NQ;
             vstate.NQ -= 1;
             vstate.NQWAIT = vstate.L;

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -40,11 +40,11 @@ const int MIN_NSE_BAILOUT_STEPS = 10;
 #endif
 
 // Type dvode_t contains the integration solution and control variables
-template<int neqs>
+template<int int_neqs>
 struct dvode_t
 {
     // Number of equations
-    static const int NEQS = neqs;
+    static const int NEQS = int_neqs;
 
     // CONP   = The saved value of TQ(5)
     amrex::Real CONP;
@@ -154,33 +154,33 @@ struct dvode_t
     amrex::Real t, tout;
 
     // Integration array
-    Array1D<Real, 1, neqs> y;
+    Array1D<Real, 1, int_neqs> y;
 
     // Jacobian
-    ArrayUtil::MathArray2D<1, neqs, 1, neqs> jac;
+    ArrayUtil::MathArray2D<1, int_neqs, 1, int_neqs> jac;
 
 #ifdef ALLOW_JACOBIAN_CACHING
     // Saved Jacobian
-    ArrayUtil::MathArray2D<1, neqs, 1, neqs> jac_save;
+    ArrayUtil::MathArray2D<1, int_neqs, 1, int_neqs> jac_save;
 #endif
 
     // the Nordsieck history array
-    amrex::Array2D<Real, 1, neqs, 1, VODE_LMAX> yh;
+    amrex::Array2D<Real, 1, int_neqs, 1, VODE_LMAX> yh;
 
-    Array1D<Real, 1, neqs> ewt, savf;
+    Array1D<Real, 1, int_neqs> ewt, savf;
 
     // Array of size NEQ used for the accumulated corrections on each
     // step, scaled in the output to represent the estimated local
     // error in Y on the last step.  This is the vector e in the
     // description of the error control.  It is defined only on a
     // successful return from DVODE.
-    Array1D<Real, 1, neqs> acor;
+    Array1D<Real, 1, int_neqs> acor;
 };
 
 #ifndef AMREX_USE_GPU
-template <int neqs>
+template <int int_neqs>
 AMREX_FORCE_INLINE
-void print_state(dvode_t<neqs>& dvode_state)
+void print_state(dvode_t<int_neqs>& dvode_state)
 {
     std::cout << "CONP = " << dvode_state.CONP << std::endl;
     std::cout << "CRATE = " << dvode_state.CRATE << std::endl;
@@ -224,25 +224,25 @@ void print_state(dvode_t<neqs>& dvode_state)
     std::cout << "NSLJ = " << dvode_state.NSLJ << std::endl;
     std::cout << "NSLP = " << dvode_state.NSLP << std::endl;
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         std::cout << "y(" << i << ") = " << dvode_state.y(i) << std::endl;
     }
 
     for (int j = 1; j <= VODE_LMAX; ++j) {
-        for (int i = 1; i <= neqs; ++i) {
+        for (int i = 1; i <= int_neqs; ++i) {
             std::cout << "yh(" << i << "," << j << ") = " << dvode_state.yh(i,j) << std::endl;
         }
     }
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         std::cout << "ewt(" << i << ") = " << dvode_state.ewt(i) << std::endl;
     }
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         std::cout << "savf(" << i << ") = " << dvode_state.savf(i) << std::endl;
     }
 
-    for (int i = 1; i <= neqs; ++i) {
+    for (int i = 1; i <= int_neqs; ++i) {
         std::cout << "acor(" << i << ") = " << dvode_state.acor(i) << std::endl;
     }
 }

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -9,10 +9,6 @@
 
 #include <integrator_data.H>
 
-typedef amrex::Array1D<short, 1, INT_NEQS> IArray1D;
-typedef amrex::Array1D<Real, 1, INT_NEQS> RArray1D;
-typedef ArrayUtil::MathArray2D<1, INT_NEQS, 1, INT_NEQS> RArray2D;
-
 const amrex::Real UROUND = std::numeric_limits<amrex::Real>::epsilon();
 
 // CCMXJ  = Threshold on DRC for updating the Jacobian
@@ -44,8 +40,12 @@ const int MIN_NSE_BAILOUT_STEPS = 10;
 #endif
 
 // Type dvode_t contains the integration solution and control variables
+template<int neqs>
 struct dvode_t
 {
+    // Number of equations
+    static const int NEQS = neqs;
+
     // CONP   = The saved value of TQ(5)
     amrex::Real CONP;
 
@@ -154,34 +154,34 @@ struct dvode_t
     amrex::Real t, tout;
 
     // Integration array
-    RArray1D y;
+    Array1D<Real, 1, neqs> y;
 
     // Jacobian
-    RArray2D jac;
+    ArrayUtil::MathArray2D<1, neqs, 1, neqs> jac;
 
 #ifdef ALLOW_JACOBIAN_CACHING
     // Saved Jacobian
-    RArray2D jac_save;
+    ArrayUtil::MathArray2D<1, neqs, 1, neqs> jac_save;
 #endif
 
     // the Nordsieck history array
-    amrex::Array2D<Real, 1, INT_NEQS, 1, VODE_LMAX> yh;
+    amrex::Array2D<Real, 1, neqs, 1, VODE_LMAX> yh;
 
-    RArray1D ewt, savf;
+    Array1D<Real, 1, neqs> ewt, savf;
 
     // Array of size NEQ used for the accumulated corrections on each
     // step, scaled in the output to represent the estimated local
     // error in Y on the last step.  This is the vector e in the
     // description of the error control.  It is defined only on a
     // successful return from DVODE.
-    RArray1D acor;
+    Array1D<Real, 1, neqs> acor;
 };
 
 #ifndef AMREX_USE_GPU
+template <int neqs>
 AMREX_FORCE_INLINE
-void print_state(dvode_t& dvode_state)
+void print_state(dvode_t<neqs>& dvode_state)
 {
-
     std::cout << "CONP = " << dvode_state.CONP << std::endl;
     std::cout << "CRATE = " << dvode_state.CRATE << std::endl;
     std::cout << "DRC = " << dvode_state.DRC << std::endl;
@@ -224,28 +224,27 @@ void print_state(dvode_t& dvode_state)
     std::cout << "NSLJ = " << dvode_state.NSLJ << std::endl;
     std::cout << "NSLP = " << dvode_state.NSLP << std::endl;
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         std::cout << "y(" << i << ") = " << dvode_state.y(i) << std::endl;
     }
 
     for (int j = 1; j <= VODE_LMAX; ++j) {
-        for (int i = 1; i <= INT_NEQS; ++i) {
+        for (int i = 1; i <= neqs; ++i) {
             std::cout << "yh(" << i << "," << j << ") = " << dvode_state.yh(i,j) << std::endl;
         }
     }
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         std::cout << "ewt(" << i << ") = " << dvode_state.ewt(i) << std::endl;
     }
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         std::cout << "savf(" << i << ") = " << dvode_state.savf(i) << std::endl;
     }
 
-    for (int i = 1; i <= INT_NEQS; ++i) {
+    for (int i = 1; i <= neqs; ++i) {
         std::cout << "acor(" << i << ") = " << dvode_state.acor(i) << std::endl;
     }
-
 }
 #endif
 

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -43,9 +43,6 @@ const int MIN_NSE_BAILOUT_STEPS = 10;
 template<int int_neqs>
 struct dvode_t
 {
-    // Number of equations
-    static const int NEQS = int_neqs;
-
     // CONP   = The saved value of TQ(5)
     amrex::Real CONP;
 

--- a/integration/integrator_data.H
+++ b/integration/integrator_data.H
@@ -20,27 +20,27 @@ const int INT_NEQS = NumSpec + 2;
 template<typename BurnT>
 constexpr int integrator_neqs ()
 {
-    int neqs = 0;
+    int int_neqs = 0;
 
 #ifdef STRANG
     if constexpr (has_xn<BurnT>::value) {
-        neqs += NumSpec;
+        int_neqs += NumSpec;
     }
 
     if constexpr (has_energy<BurnT>::value) {
-        neqs += 1;
+        int_neqs += 1;
     }
 #endif
 
 #ifdef SIMPLIFIED_SDC
-    neqs = SVAR_EVOLVE;
+    int_neqs = SVAR_EVOLVE;
 #endif
 
 #ifdef TRUE_SDC
-    neqs = NumSpec + 2;
+    int_neqs = NumSpec + 2;
 #endif
 
-    return neqs;
+    return int_neqs;
 }
 
 typedef amrex::Array1D<short, 1, INT_NEQS> IArray1D;

--- a/integration/integrator_data.H
+++ b/integration/integrator_data.H
@@ -17,6 +17,32 @@ const int INT_NEQS = SVAR_EVOLVE;
 const int INT_NEQS = NumSpec + 2;
 #endif
 
+template<typename BurnT>
+constexpr int integrator_neqs ()
+{
+    int neqs = 0;
+
+#ifdef STRANG
+    if constexpr (has_xn<BurnT>::value) {
+        neqs += NumSpec;
+    }
+
+    if constexpr (has_energy<BurnT>::value) {
+        neqs += 1;
+    }
+#endif
+
+#ifdef SIMPLIFIED_SDC
+    neqs = SVAR_EVOLVE;
+#endif
+
+#ifdef TRUE_SDC
+    neqs = NumSpec + 2;
+#endif
+
+    return neqs;
+}
+
 typedef amrex::Array1D<short, 1, INT_NEQS> IArray1D;
 typedef amrex::Array1D<Real, 1, INT_NEQS> RArray1D;
 typedef ArrayUtil::MathArray2D<1, INT_NEQS, 1, INT_NEQS> RArray2D;


### PR DESCRIPTION
With this change, the number of equations integrated by VODE is now counted from the components of the burn_t, rather than being hardcoded at compile time (at least for Strang; SDC will be handled in a future change). This sets up a possible future change where different burn state objects are passed to the integrator at different times. The motivating use case is Quokka's desire to integrate (xn, e) at some times and (e_gas, e_radiation) at other times. A future change could support the integration of an object other than burn_t, particularly an object that does not have xn but has (multigroup) radiation energy, as long as the integration tolerances (and any other auxiliary information) are made consistent.