### PR TITLE
simplify some logic in the SDC integrators

### DIFF
--- a/integration/BackwardEuler/actual_integrator_simplified_sdc.H
+++ b/integration/BackwardEuler/actual_integrator_simplified_sdc.H
@@ -90,7 +90,7 @@ void actual_integrator (BurnT& state, const Real dt)
 
     Real rho_Sdot = 0.0_rt;
     if (state.time > 0) {
-        rho_Sdot = (be.y(SEINT+1) - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
+        rho_Sdot = (state.y[SEINT] - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
     }
 
     state.y[SEDEN] += state.time * (state.ydot_a[SEDEN] + rho_Sdot);
@@ -130,7 +130,7 @@ void actual_integrator (BurnT& state, const Real dt)
         std::cout << Font::Bold << FGColor::Red << "[ERROR] integration failed in net" << ResetDisplay << std::endl;
         std::cout << "istate = " << istate << std::endl;
         std::cout << "zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
-        std::cout << "time = " << be.t << std::endl;
+        std::cout << "time = " << state.time << std::endl;
         std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
         std::cout << "dens start = " << std::setprecision(16) << state.rho_orig << std::endl;
         std::cout << "temp start = " << std::setprecision(16) << T_in << std::endl;

--- a/integration/RKC/actual_integrator_simplified_sdc.H
+++ b/integration/RKC/actual_integrator_simplified_sdc.H
@@ -98,7 +98,7 @@ void actual_integrator (BurnT& state, Real dt)
 
     Real rho_Sdot = 0.0_rt;
     if (state.time > 0) {
-        rho_Sdot = (rkc_state.y(SEINT+1) - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
+        rho_Sdot = (state.y[SEINT] - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
     }
 
     state.y[SEDEN] += state.time * (state.ydot_a[SEDEN] + rho_Sdot);
@@ -123,16 +123,16 @@ void actual_integrator (BurnT& state, Real dt)
         state.success = false;
     }
 
-    if (rkc_state.y(SEINT+1) < 0.0_rt) {
+    if (state.y[SEINT] < 0.0_rt) {
         state.success = false;
     }
 
-    for (int n = 1; n <= NumSpec; ++n) {
-        if (rkc_state.y(SFS+n) / state.y[SRHO] < -species_failure_tolerance) {
+    for (int n = 0; n < NumSpec; ++n) {
+        if (state.y[SFS+n] / state.rho < -species_failure_tolerance) {
             state.success = false;
         }
 
-        if (rkc_state.y(SFS+n) / state.y[SRHO] > 1.0_rt + species_failure_tolerance) {
+        if (state.y[SFS+n] / state.rho > 1.0_rt + species_failure_tolerance) {
             state.success = false;
         }
     }
@@ -144,8 +144,8 @@ void actual_integrator (BurnT& state, Real dt)
         std::cout <<  "integration summary: " << std::endl;
         std::cout <<  "dens: " << state.rho << " temp: " << state.T << std::endl;
         std::cout << " energy released: " << state.e << std::endl;
-        std::cout <<  "number of steps taken: " << rkc_state.nsteps << std::endl;
-        std::cout <<  "number of f evaluations: " << rkc_state.nfe << std::endl;
+        std::cout <<  "number of steps taken: " << state.n_step << std::endl;
+        std::cout <<  "number of f evaluations: " << state.n_rhs << std::endl;
     }
 #endif
 
@@ -156,7 +156,7 @@ void actual_integrator (BurnT& state, Real dt)
         std::cout << Font::Bold << FGColor::Red << "[ERROR] integration failed in net" << ResetDisplay << std::endl;
         std::cout << "ierr = " << ierr << std::endl;
         std::cout << "zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
-        std::cout << "time = " << rkc_state.t << std::endl;
+        std::cout << "time = " << state.time << std::endl;
         std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
         std::cout << "dens start = " << std::setprecision(16) << state.rho_orig << std::endl;
         std::cout << "temp start = " << std::setprecision(16) << T_in << std::endl;

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -102,7 +102,7 @@ void actual_integrator (BurnT& state, Real dt)
 
     Real rho_Sdot = 0.0_rt;
     if (state.time > 0) {
-        rho_Sdot = (vode_state.y(SEINT+1) - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
+        rho_Sdot = (state.y[SEINT] - state.rhoe_orig) / state.time - state.ydot_a[SEINT];
     }
 
     state.y[SEDEN] += state.time * (state.ydot_a[SEDEN] + rho_Sdot);
@@ -127,16 +127,16 @@ void actual_integrator (BurnT& state, Real dt)
         state.success = false;
     }
 
-    if (vode_state.y(SEINT+1) < 0.0_rt) {
+    if (state.y[SEINT] < 0.0_rt) {
         state.success = false;
     }
 
-    for (int n = 1; n <= NumSpec; ++n) {
-        if (vode_state.y(SFS+n) / state.y[SRHO] < -species_failure_tolerance) {
+    for (int n = 0; n < NumSpec; ++n) {
+        if (state.y[SFS+n] / state.rho < -species_failure_tolerance) {
             state.success = false;
         }
 
-        if (vode_state.y(SFS+n) / state.y[SRHO] > 1.0_rt + species_failure_tolerance) {
+        if (state.y[SFS+n] / state.rho > 1.0_rt + species_failure_tolerance) {
             state.success = false;
         }
     }
@@ -148,8 +148,8 @@ void actual_integrator (BurnT& state, Real dt)
         std::cout <<  "integration summary: " << std::endl;
         std::cout <<  "dens: " << state.rho << " temp: " << state.T << std::endl;
         std::cout << " energy released: " << state.e << std::endl;
-        std::cout <<  "number of steps taken: " << vode_state.NST << std::endl;
-        std::cout <<  "number of f evaluations: " << vode_state.NFE << std::endl;
+        std::cout <<  "number of steps taken: " << state.n_step << std::endl;
+        std::cout <<  "number of f evaluations: " << state.n_rhs << std::endl;
     }
 #endif
 
@@ -164,7 +164,7 @@ void actual_integrator (BurnT& state, Real dt)
                 std::cout << "  VODE exited successfully, but a check on the data values failed" << std::endl;
             }
             std::cout << "zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
-            std::cout << "time = " << vode_state.t << std::endl;
+            std::cout << "time = " << state.time << std::endl;
             std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
             std::cout << "dens start = " << std::setprecision(16) << state.rho_orig << std::endl;
             std::cout << "temp start = " << std::setprecision(16) << T_in << std::endl;
@@ -212,7 +212,7 @@ void actual_integrator (BurnT& state, Real dt)
 #endif
         } else {
 #ifndef AMREX_USE_GPU
-            std::cout << "burn entered NSE during integration (after " << vode_state.NST << " steps), zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
+            std::cout << "burn entered NSE during integration (after " << state.n_step << " steps), zone = (" << state.i << ", " << state.j << ", " << state.k << ")" << std::endl;
 #endif
         }
     }


### PR DESCRIPTION
basically, once we convert back from the integrator type to the burn_t, we should not have to use the integrator type any more.  This will make it easier to merge these code paths in the future.