### PR TITLE
store the error code returned by the integrator in burn_t

### DIFF
--- a/integration/BackwardEuler/actual_integrator.H
+++ b/integration/BackwardEuler/actual_integrator.H
@@ -70,6 +70,7 @@ void actual_integrator (BurnT& state, const Real dt)
     // Call the integration routine.
 
     int istate = be_integrator(state, be);
+    state.error_code = istate;
 
     // Copy the integration data back to the burn state.
 

--- a/integration/BackwardEuler/actual_integrator_simplified_sdc.H
+++ b/integration/BackwardEuler/actual_integrator_simplified_sdc.H
@@ -73,6 +73,7 @@ void actual_integrator (BurnT& state, const Real dt)
     // Call the integration routine.
 
     int istate = be_integrator(state, be);
+    state.error_code = istate;
 
     // Get the number of RHS and Jacobian evaluations.
 

--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -10,6 +10,7 @@
 #include <eos.H>
 #include <extern_parameters.H>
 #include <fe_type.H>
+#include <integrator_data.H>
 
 using namespace integrator_rp;
 
@@ -121,6 +122,7 @@ void initialize_state (BurnT& state)
     eos(eos_input_rt, state);
 
     state.success = true;
+    state.error_code = IERR_SUCCESS;
 
     // Initialize ydot to zero for Strang burn.
 
@@ -212,6 +214,7 @@ void actual_integrator (BurnT& state, Real dt)
 
     if (fe.n_step >= ode_max_steps) {
         state.success = false;
+        state.error_code = IERR_TOO_MANY_STEPS;
     }
 
     state.time = fe.t;

--- a/integration/QSS/actual_integrator.H
+++ b/integration/QSS/actual_integrator.H
@@ -10,6 +10,7 @@
 #include <eos_type.H>
 #include <eos.H>
 #include <extern_parameters.H>
+#include <integrator_data.H>
 
 using namespace integrator_rp;
 
@@ -42,6 +43,7 @@ void initialize_state (BurnT& state)
     eos(eos_input_rt, state);
 
     state.success = true;
+    state.error_code = IERR_SUCCESS;
 
     state.time = 0.0;
     state.n_rhs = 0;
@@ -374,6 +376,7 @@ void actual_integrator (BurnT& state, Real dt)
 
         if (timestep_iter >= num_timestep_iters) {
             state.success = false;
+            state.error_code = IERR_CORRECTOR_CONVERGENCE;
             break;
         }
 
@@ -386,6 +389,7 @@ void actual_integrator (BurnT& state, Real dt)
 
     if (num_timesteps >= ode_max_steps) {
         state.success = false;
+        state.error_code = IERR_TOO_MANY_STEPS;
     }
 
     state.time = t;

--- a/integration/RKC/actual_integrator.H
+++ b/integration/RKC/actual_integrator.H
@@ -74,6 +74,7 @@ void actual_integrator (BurnT& state, Real dt)
     // Call the integration routine.
 
     int ierr = rkc(state, rkc_state);
+    state.error_code = ierr;
 
     // Copy the integration data back to the burn state.
 

--- a/integration/RKC/actual_integrator_simplified_sdc.H
+++ b/integration/RKC/actual_integrator_simplified_sdc.H
@@ -76,6 +76,7 @@ void actual_integrator (BurnT& state, Real dt)
     // Call the integration routine.
 
     int ierr = rkc(state, rkc_state);
+    state.error_code = ierr;
 
     // Get the number of RHS and Jacobian evaluations.
 

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -86,6 +86,7 @@ void actual_integrator (BurnT& state, Real dt)
     // Call the integration routine.
 
     int istate = dvode(state, vode_state);
+    state.error_code = istate;
 
     // Copy the integration data back to the burn state.
 

--- a/integration/VODE/actual_integrator_simplified_sdc.H
+++ b/integration/VODE/actual_integrator_simplified_sdc.H
@@ -85,6 +85,7 @@ void actual_integrator (BurnT& state, Real dt)
     // Call the integration routine.
 
     int istate = dvode(state, vode_state);
+    state.error_code = istate;
 
     // Get the number of RHS and Jacobian evaluations.
 

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -158,6 +158,10 @@ struct burn_t
 
   // Was the burn successful?
   bool success;
+
+  // integrator error code
+  short error_code;
+
 };
 
 


### PR DESCRIPTION
this will allow the application code to be more descriptive about failures