### PR TITLE
remove init_nse_net

### DIFF
--- a/interfaces/network_initialization.cpp
+++ b/interfaces/network_initialization.cpp
@@ -28,10 +28,6 @@ nonaka_init();
     actual_rhs_init();
 #endif
 
-#ifdef NSE_NET
-    init_nse_net();
-#endif
-
 #endif
 
 }

--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -37,7 +37,6 @@ namespace NSE_INDEX
     constexpr int h1_index = -1;
     constexpr int n_index = -1;
     constexpr int he4_index = 0;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/networks/aprox13/actual_network_data.cpp
+++ b/networks/aprox13/actual_network_data.cpp
@@ -7,13 +7,6 @@ namespace network
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
 }
 
-#ifdef NSE_NET
-namespace NSE_INDEX
-{
-    AMREX_GPU_MANAGED bool initialized = false;
-}
-#endif
-
 void actual_network_init()
 {
     using namespace Species;

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -62,7 +62,6 @@ namespace NSE_INDEX
     constexpr int h1_index = 0;
     constexpr int n_index = 17;
     constexpr int he4_index = 2;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/networks/aprox19/actual_network_data.cpp
+++ b/networks/aprox19/actual_network_data.cpp
@@ -23,13 +23,6 @@ namespace table
 }
 #endif
 
-#ifdef NSE_NET
-namespace NSE_INDEX
-{
-    AMREX_GPU_MANAGED bool initialized = false;
-}
-#endif
-
 void actual_network_init()
 {
     using namespace Species;

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -36,7 +36,6 @@ namespace NSE_INDEX
     constexpr int h1_index = 0;
     constexpr int n_index = 19;
     constexpr int he4_index = 2;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/networks/aprox21/actual_network_data.cpp
+++ b/networks/aprox21/actual_network_data.cpp
@@ -7,13 +7,6 @@ namespace network
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
 }
 
-#ifdef NSE_NET
-namespace NSE_INDEX
-{
-    AMREX_GPU_MANAGED bool initialized = false;
-}
-#endif
-
 void actual_network_init()
 {
     using namespace Species;

--- a/networks/ignition_simple/actual_network.H
+++ b/networks/ignition_simple/actual_network.H
@@ -31,7 +31,6 @@ namespace NSE_INDEX
     constexpr int h1_index = -1;
     constexpr int n_index = -1;
     constexpr int he4_index = -1;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/networks/ignition_simple/actual_network_data.cpp
+++ b/networks/ignition_simple/actual_network_data.cpp
@@ -6,13 +6,6 @@ namespace network
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> mion;
 }
 
-#ifdef NSE_NET
-namespace NSE_INDEX
-{
-    AMREX_GPU_MANAGED bool initialized = false;
-}
-#endif
-
 void actual_network_init()
 {
     using namespace Species;

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -35,7 +35,6 @@ namespace NSE_INDEX
     constexpr int h1_index = -1;
     constexpr int n_index = -1;
     constexpr int he4_index = 0;
-    extern AMREX_GPU_MANAGED bool initialized;
 }
 #endif
 

--- a/networks/iso7/actual_network_data.cpp
+++ b/networks/iso7/actual_network_data.cpp
@@ -8,13 +8,6 @@ namespace network
     AMREX_GPU_MANAGED amrex::Array1D<amrex::Real, 1, NumSpec> wion;
 }
 
-#ifdef NSE_NET
-namespace NSE_INDEX
-{
-    AMREX_GPU_MANAGED bool initialized = false;
-}
-#endif
-
 void actual_network_init()
 {
     using namespace Species;

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -19,38 +19,6 @@
 
 using namespace nse_rp;
 
-AMREX_INLINE
-void init_nse_net() {
-  // Initialization for nse
-
-  // Check if network results in singular jacobian first, require at
-  // least one nuclei that nuclei.Z != nuclei.N.  Some examples include
-  // aprox13 and iso7. If use hybrj solver, this is no longer an issue.
-
-  if (!use_hybrid_solver) {
-    bool singular_network = true;
-    for (int n = 0; n < NumSpec; ++n) {
-
-#ifdef NEW_NETWORK_IMPLEMENTATION
-      if (n == NSE_INDEX::h1_index) {
-	continue;
-      }
-#endif
-
-      if (zion[n] != aion[n] - zion[n]) {
-	singular_network = false;
-      }
-    }
-
-    if (singular_network == true) {
-      amrex::Error("This network always results in singular jacobian matrix, thus can't find nse mass fraction using nr!");
-    }
-  }
-
-  NSE_INDEX::initialized = true;
-}
-
-
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 T get_nse_state(const T& state) {
@@ -439,10 +407,6 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 T get_actual_nse_state(T& state, amrex::Real eps=1.0e-10_rt,
                        bool input_ye_is_valid=false) {
 
-  // Check whether initialized or not
-  if (!NSE_INDEX::initialized) {
-    amrex::Error("NSE uninitialized! Need to call init_nse_net() ");
-  }
   // Check whether input ye is actually valid
   amrex::Real ye_lo = 1.0_rt;
   amrex::Real ye_hi = 0.0_rt;
@@ -480,6 +444,22 @@ T get_actual_nse_state(T& state, amrex::Real eps=1.0e-10_rt,
     nse_hybrid_solver(state, eps);
   }
   else {
+    bool singular_network = true;
+    for (int n = 0; n < NumSpec; ++n) {
+#ifdef NEW_NETWORK_IMPLEMENTATION
+      if (n == NSE_INDEX::h1_index) {
+	continue;
+      }
+#endif
+      if (zion[n] != aion[n] - zion[n]) {
+	singular_network = false;
+      }
+    }
+
+    if (singular_network == true) {
+      amrex::Error("This network always results in singular jacobian matrix, thus can't find nse mass fraction using nr!");
+    }
+
     nse_nr_solver(state, eps);
   }
 


### PR DESCRIPTION
we used to have `init_nse_net` to compute `rate_indices`, but now we generate them directly. Therefore, it is really not needed anymore.