### PR TITLE
Fix remaining clang-tidy warnings

### DIFF
--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -1341,10 +1341,10 @@ void actual_eos_init ()
     // buffer, broadcast that, and then copy that into the managed
     // memory.
 
-    amrex::Vector<Real> f_local(jmax * imax * 9);
-    amrex::Vector<Real> dpdf_local(jmax * imax * 4);
-    amrex::Vector<Real> ef_local(jmax * imax * 4);
-    amrex::Vector<Real> xf_local(jmax * imax * 4);
+    amrex::Vector<Real> f_local(static_cast<size_t>(9) * imax * jmax);
+    amrex::Vector<Real> dpdf_local(static_cast<size_t>(4) * imax * jmax);
+    amrex::Vector<Real> ef_local(static_cast<size_t>(4) * imax * jmax);
+    amrex::Vector<Real> xf_local(static_cast<size_t>(4) * imax * jmax);
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
 
@@ -1412,10 +1412,10 @@ void actual_eos_init ()
 
     }
 
-    amrex::ParallelDescriptor::Bcast(f_local.data(),    static_cast<size_t>(9 * imax * jmax));
-    amrex::ParallelDescriptor::Bcast(dpdf_local.data(), static_cast<size_t>(4 * imax * jmax));
-    amrex::ParallelDescriptor::Bcast(ef_local.data(),   static_cast<size_t>(4 * imax * jmax));
-    amrex::ParallelDescriptor::Bcast(xf_local.data(),   static_cast<size_t>(4 * imax * jmax));
+    amrex::ParallelDescriptor::Bcast(f_local.data(),    static_cast<size_t>(9) * imax * jmax);
+    amrex::ParallelDescriptor::Bcast(dpdf_local.data(), static_cast<size_t>(4) * imax * jmax);
+    amrex::ParallelDescriptor::Bcast(ef_local.data(),   static_cast<size_t>(4) * imax * jmax);
+    amrex::ParallelDescriptor::Bcast(xf_local.data(),   static_cast<size_t>(4) * imax * jmax);
 
     // now copy into managed memory
     int idx = 0;

--- a/EOS/helmholtz/actual_eos.H
+++ b/EOS/helmholtz/actual_eos.H
@@ -1419,7 +1419,7 @@ void actual_eos_init ()
 
     // now copy into managed memory
     int idx = 0;
-    for (int j = 0; j < jmax; ++j) {
+    for (int j = 0; j < jmax; ++j) {  // NOLINT(modernize-loop-convert)
         for (int i = 0; i < imax; ++i) {
             for (int m = 0; m < 9; ++m) {
                 f[j][i][m] = f_local[idx];

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -33,7 +33,7 @@ void actual_integrator (BurnT& state, Real dt)
     vode_state.rtol_enuc = rtol_enuc; // energy generated
 
     // set the Jacobian type
-    vode_state.jacobian_type = jacobian;
+    vode_state.jacobian_type = static_cast<short>(jacobian);
 
     // Start off by assuming a successful burn.
 

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -172,15 +172,15 @@ void actual_integrator (BurnT& state, Real dt)
             std::cout << "dt = " << std::setprecision(16) << dt << std::endl;
             std::cout << "temp start = " << std::setprecision(16) << T_in << std::endl;
             std::cout << "xn start = ";
-            for (int n = 0; n < NumSpec; ++n) {
-                std::cout << std::setprecision(16) << xn_in[n] << " ";
+            for (double x : xn_in) {
+                std::cout << std::setprecision(16) << x << " ";
             }
             std::cout << std::endl;
             std::cout << "dens current = " << std::setprecision(16) << state.rho << std::endl;
             std::cout << "temp current = " << std::setprecision(16) << state.T << std::endl;
             std::cout << "xn current = ";
-            for (int n = 0; n < NumSpec; ++n) {
-                std::cout << std::setprecision(16) << state.xn[n] << " ";
+            for (double x : state.xn) {
+                std::cout << std::setprecision(16) << x << " ";
             }
             std::cout << std::endl;
             std::cout << "energy generated = " << state.e << std::endl;

--- a/interfaces/ArrayUtilities.H
+++ b/interfaces/ArrayUtilities.H
@@ -20,13 +20,6 @@ namespace ArrayUtil
         }
 
         AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator= (const MathArray1D<XLO, XHI>& other) noexcept {
-            for (int i = 0; i < (XHI-XLO+1); ++i) {
-                arr[i] = other.arr[i];
-            }
-        }
-
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         const Real& operator() (int i) const noexcept {
             AMREX_ASSERT(i >= XLO && i <= XHI);
             return arr[i-XLO];
@@ -87,13 +80,6 @@ namespace ArrayUtil
         void add_identity () noexcept {
             for (int i = XLO; i <= XHI; ++i) {
                 arr[i+i*(XHI-XLO+1)-(YLO*(XHI-XLO+1)+XLO)] += 1.0_rt;
-            }
-        }
-
-        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-        void operator= (const MathArray2D<XLO, XHI, YLO, YHI>& other) noexcept {
-            for (int i = 0; i < (YHI-YLO+1)*(XHI-XLO+1); ++i) {
-                arr[i] = other.arr[i];
             }
         }
 

--- a/interfaces/burn_type.H
+++ b/interfaces/burn_type.H
@@ -365,12 +365,12 @@ void normalize_abundances_burn (BurnT& state)
 {
 
     Real sum = 0.0_rt;
-    for (int n = 0; n < NumSpec; ++n) {
-        state.xn[n] = amrex::max(small_x, amrex::min(1.0_rt, state.xn[n]));
-        sum += state.xn[n];
+    for (double &x : state.xn) {
+        x = amrex::max(small_x, amrex::min(1.0_rt, x));
+        sum += x;
     }
-    for (int n = 0; n < NumSpec; ++n) {
-        state.xn[n] /= sum;
+    for (double &x : state.xn) {
+        x /= sum;
     }
 
 }

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -161,7 +161,7 @@ struct has_energy
     : std::false_type {};
 
 template <typename T>
-struct has_energy<T, typename std::enable_if<(sizeof(((T*)0)->e) > 0)>::type>
+struct has_energy<T, decltype((void)T::e, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -169,7 +169,7 @@ struct has_enthalpy
     : std::false_type {};
 
 template <typename T>
-struct has_enthalpy<T, typename std::enable_if<(sizeof(((T*)0)->h) > 0)>::type>
+struct has_enthalpy<T, decltype((void)T::h, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -177,7 +177,7 @@ struct has_entropy
     : std::false_type {};
 
 template <typename T>
-struct has_entropy<T, typename std::enable_if<(sizeof(((T*)0)->s) > 0)>::type>
+struct has_entropy<T, decltype((void)T::s, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -185,7 +185,7 @@ struct has_pressure
     : std::false_type {};
 
 template <typename T>
-struct has_pressure<T, typename std::enable_if<(sizeof(((T*)0)->p) > 0)>::type>
+struct has_pressure<T, decltype((void)T::p, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -193,7 +193,7 @@ struct has_dpdA
     : std::false_type {};
 
 template <typename T>
-struct has_dpdA<T, typename std::enable_if<(sizeof(((T*)0)->dpdA) > 0)>::type>
+struct has_dpdA<T, decltype((void)T::dpdA, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -201,7 +201,7 @@ struct has_dpdZ
     : std::false_type {};
 
 template <typename T>
-struct has_dpdZ<T, typename std::enable_if<(sizeof(((T*)0)->dpdZ) > 0)>::type>
+struct has_dpdZ<T, decltype((void)T::dpdZ, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -209,7 +209,7 @@ struct has_dedA
     : std::false_type {};
 
 template <typename T>
-struct has_dedA<T, typename std::enable_if<(sizeof(((T*)0)->dedA) > 0)>::type>
+struct has_dedA<T, decltype((void)T::dedA, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -217,7 +217,7 @@ struct has_dedZ
     : std::false_type {};
 
 template <typename T>
-struct has_dedZ<T, typename std::enable_if<(sizeof(((T*)0)->dedZ) > 0)>::type>
+struct has_dedZ<T, decltype((void)T::dedZ, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -225,7 +225,7 @@ struct has_pele_ppos
     : std::false_type {};
 
 template <typename T>
-struct has_pele_ppos<T, typename std::enable_if<(sizeof(((T*)0)->pele) > 0)>::type>
+struct has_pele_ppos<T, decltype((void)T::pele, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -233,7 +233,7 @@ struct has_xne_xnp
     : std::false_type {};
 
 template <typename T>
-struct has_xne_xnp<T, typename std::enable_if<(sizeof(((T*)0)->xne) > 0)>::type>
+struct has_xne_xnp<T, decltype((void)T::xne, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -241,7 +241,7 @@ struct has_eta
     : std::false_type {};
 
 template <typename T>
-struct has_eta<T, typename std::enable_if<(sizeof(((T*)0)->eta) > 0)>::type>
+struct has_eta<T, decltype((void)T::eta, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -249,7 +249,7 @@ struct has_conductivity
     : std::false_type {};
 
 template <typename T>
-struct has_conductivity<T, typename std::enable_if<(sizeof(((T*)0)->conductivity) > 0)>::type>
+struct has_conductivity<T, decltype((void)T::conductivity, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -257,7 +257,7 @@ struct has_xn
     : std::false_type {};
 
 template <typename T>
-struct has_xn<T, typename std::enable_if<(sizeof(((T*)0)->xn) > 0)>::type>
+struct has_xn<T, decltype((void)T::xn, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
@@ -265,7 +265,7 @@ struct has_base_variables
     : std::false_type {};
 
 template <typename T>
-struct has_base_variables<T, typename std::enable_if<(sizeof(((T*)0)->rho) > 0)>::type>
+struct has_base_variables<T, decltype((void)T::rho, void())>
     : std::true_type {};
 
 template <typename T>

--- a/interfaces/rhs_type.H
+++ b/interfaces/rhs_type.H
@@ -38,70 +38,40 @@ namespace RHS
 {
 
 struct rhs_t {
-    int species_A;
-    int species_B;
-    int species_C;
-    int species_D;
-    int species_E;
-    int species_F;
+    int species_A{-1};
+    int species_B{-1};
+    int species_C{-1};
+    int species_D{-1};
+    int species_E{-1};
+    int species_F{-1};
 
-    int number_A;
-    int number_B;
-    int number_C;
-    int number_D;
-    int number_E;
-    int number_F;
+    int number_A{0};
+    int number_B{0};
+    int number_C{0};
+    int number_D{0};
+    int number_E{0};
+    int number_F{0};
 
-    int exponent_A;
-    int exponent_B;
-    int exponent_C;
-    int exponent_D;
-    int exponent_E;
-    int exponent_F;
+    int exponent_A{0};
+    int exponent_B{0};
+    int exponent_C{0};
+    int exponent_D{0};
+    int exponent_E{0};
+    int exponent_F{0};
 
-    amrex::Real forward_branching_ratio;
-    amrex::Real reverse_branching_ratio;
+    amrex::Real forward_branching_ratio{1.0_rt};
+    amrex::Real reverse_branching_ratio{1.0_rt};
 
-    int apply_identical_particle_factor;
+    int apply_identical_particle_factor{1};
 
-    int rate_can_be_tabulated;
+    int rate_can_be_tabulated{1};
 
-    int screen_forward_reaction;
-    int screen_reverse_reaction;
+    int screen_forward_reaction{1};
+    int screen_reverse_reaction{1};
 
-    int additional_reaction_1;
-    int additional_reaction_2;
-    int additional_reaction_3;
-
-    constexpr rhs_t ()
-        : species_A(-1),
-          species_B(-1),
-          species_C(-1),
-          species_D(-1),
-          species_E(-1),
-          species_F(-1),
-          number_A(0),
-          number_B(0),
-          number_C(0),
-          number_D(0),
-          number_E(0),
-          number_F(0),
-          exponent_A(0),
-          exponent_B(0),
-          exponent_C(0),
-          exponent_D(0),
-          exponent_E(0),
-          exponent_F(0),
-          forward_branching_ratio(1.0_rt),
-          reverse_branching_ratio(1.0_rt),
-          apply_identical_particle_factor(1),
-          rate_can_be_tabulated(1),
-          screen_forward_reaction(1),
-          screen_reverse_reaction(1),
-          additional_reaction_1(-1),
-          additional_reaction_2(-1),
-          additional_reaction_3(-1)
-        {}
+    int additional_reaction_1{-1};
+    int additional_reaction_2{-1};
+    int additional_reaction_3{-1};
 };
 
 constexpr amrex::Real tab_tlo = 6.0e0_rt;

--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -798,19 +798,10 @@ namespace RHS {
         else if constexpr (rate == C12_C12_to_Ne20_He4) {
             rate_c12c12(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
         }
-        else if constexpr (rate == C12_O16_to_Mg24_He4) {
+        else if constexpr (rate == C12_O16_to_Mg24_He4 || rate == C12_O16_to_Si28) {
             rate_c12o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
         }
-        else if constexpr (rate == C12_O16_to_Si28) {
-            rate_c12o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
-        }
-        else if constexpr (rate == O16_O16_to_Si28_He4) {
-            rate_o16o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
-        }
-        else if constexpr (rate == O16_O16_to_P31_P) {
-            rate_o16o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
-        }
-        else if constexpr (rate == O16_O16_to_S32) {
+        else if constexpr (rate == O16_O16_to_Si28_He4 || rate == O16_O16_to_P31_P || rate == O16_O16_to_S32) {
             rate_o16o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
         }
         else if constexpr (rate == O16_He4_to_Ne20) {

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -33,7 +33,7 @@ namespace network
         static_assert(spec >= 1 && spec <= NumSpec);
 
         // Set the binding energy of the element
-        if constexpr (spec == H1) {
+        if constexpr (spec == H1 || spec == N || spec == P) {
             return 0.0_rt;
         }
         else if constexpr (spec == He3) {
@@ -89,12 +89,6 @@ namespace network
         }
         else if constexpr (spec == Ni56) {
             return 484.00300e0_rt;
-        }
-        else if constexpr (spec == N) {
-            return 0.0_rt;
-        }
-        else if constexpr (spec == P) {
-            return 0.0_rt;
         }
 
         // Return zero if we don't recognize the species.

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -329,10 +329,7 @@ namespace RHS {
         else if constexpr (rate == C12_C12_to_Ne20_He4) {
             rate_c12c12(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
         }
-        else if constexpr (rate == C12_O16_to_Mg24_He4) {
-            rate_c12o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
-        }
-        else if constexpr (rate == C12_O16_to_Si28) {
+        else if constexpr (rate == C12_O16_to_Mg24_He4 || rate == C12_O16_to_Si28) {
             rate_c12o16(state.tf, 1.0_rt, rates.fr, rates.frdt, rates.rr, rates.rrdt);
         }
         else if constexpr (rate == O16_O16_to_Si28_He4) {

--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -1344,9 +1344,9 @@ void rhs (burn_t& burn_state, Array1D<Real, 1, nrhs>& ydot)
 
     // Evaluate the neutrino cooling.
 #ifdef NEUTRINOS
-    Real sneut, dsneutdt, dsneutdd, snuda, snudz;
+    Real sneut, dsneutdt, dsneutdd, dsnuda, dsnudz;
     sneut5(burn_state.T, burn_state.rho, burn_state.abar, burn_state.zbar,
-           sneut, dsneutdt, dsneutdd, snuda, snudz);
+           sneut, dsneutdt, dsneutdd, dsnuda, dsnudz);
 #else
     Real sneut = 0.0;
 #endif
@@ -1488,11 +1488,12 @@ void jac (burn_t& burn_state, ArrayUtil::MathArray2D<1, neqs, 1, neqs>& jac)
 
     // Evaluate the neutrino cooling.
 #ifdef NEUTRINOS
-    Real sneut, dsneutdt, dsneutdd, snuda, snudz;
+    Real sneut, dsneutdt, dsneutdd, dsnuda, dsnudz;
     sneut5(burn_state.T, burn_state.rho, burn_state.abar, burn_state.zbar,
-           sneut, dsneutdt, dsneutdd, snuda, snudz);
+           sneut, dsneutdt, dsneutdd, dsnuda, dsnudz);
 #else
-    Real sneut = 0.0, dsneutdt = 0.0, dsneutdd = 0.0, snuda = 0.0, snudz = 0.0;
+    Real sneut = 0.0, dsneutdt = 0.0, dsneutdd = 0.0, dsnuda = 0.0, dsnudz = 0.0;
+    amrex::ignore_unused(sneut, dsneutdd);
 #endif
 
     jac(net_ienuc, net_ienuc) = -temperature_to_energy_jacobian(burn_state, dsneutdt);
@@ -1502,7 +1503,7 @@ void jac (burn_t& burn_state, ArrayUtil::MathArray2D<1, neqs, 1, neqs>& jac)
         constexpr int species = j;
 
         // Energy generation rate Jacobian elements with respect to species.
-        Real b1 = (-burn_state.abar * burn_state.abar * snuda + (NetworkProperties::zion(species) - burn_state.zbar) * burn_state.abar * snudz);
+        Real b1 = (-burn_state.abar * burn_state.abar * dsnuda + (NetworkProperties::zion(species) - burn_state.zbar) * burn_state.abar * dsnudz);
         jac(net_ienuc, species) = -b1;
 
         constexpr_for<1, NumSpec+1>([&] (auto i)

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -33,7 +33,7 @@ T get_nonexponent_nse_state(const T& state) {
   // set partition function and spin
   
   amrex::Real pf = 1.0_rt;
-  amrex::Real dpf_dT;
+  [[maybe_unused]] amrex::Real dpf_dT;
   amrex::Real spin = 1.0_rt;
 
   // if we are doing drive_initial_convection, we want to use
@@ -165,6 +165,7 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void fcn(Array1D<Real, 1, 2>& x, Array1D<Real, 1, 2>& fvec,
                 const T& state, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
+    amrex::ignore_unused(iflag);
   
     T nse_state = state;
     nse_state.mu_p = x(1);
@@ -200,6 +201,7 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void jcn(Array1D<Real, 1, 2>& x, Array2D<Real, 1, 2, 1, 2>& fjac,
                 const T& state, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
+    amrex::ignore_unused(iflag);
   
     T nse_state = state;
     nse_state.mu_p = x(1);

--- a/screening/screen_data.H
+++ b/screening/screen_data.H
@@ -32,8 +32,9 @@ namespace scrn {
       amrex::Real aznut = 0.0;
       amrex::Real ztilde = 0.0;
 
+      [[nodiscard]]
       bool validate_nuclei(const amrex::Real z1_pass, const amrex::Real a1_pass,
-                           const amrex::Real z2_pass, const amrex::Real a2_pass) {
+                           const amrex::Real z2_pass, const amrex::Real a2_pass) const {
         // a simple function for unit testing / debug runs to
         // ensure that we are accessing the proper screening info
 

--- a/unit_test/test_react/main.cpp
+++ b/unit_test/test_react/main.cpp
@@ -272,13 +272,14 @@ void main_main ()
         // Tell the I/O Processor to write out the "run time"
         amrex::Print() << "Run time = " << stop_time << std::endl;
 
+        long n_cell_cubed = static_cast<long>(n_cell) * n_cell * n_cell;
         // print statistics
         std::cout << "min number of rhs calls: " << n_rhs_min << std::endl;
-        std::cout << "avg number of rhs calls: " << n_rhs_sum / (n_cell*n_cell*n_cell) << std::endl;
+        std::cout << "avg number of rhs calls: " << n_rhs_sum / n_cell_cubed << std::endl;
         std::cout << "max number of rhs calls: " << n_rhs_max << std::endl;
 
         std::cout << "min number of steps: " << n_step_min << std::endl;
-        std::cout << "avg number of steps: " << n_step_sum / (n_cell*n_cell*n_cell) << std::endl;
+        std::cout << "avg number of steps: " << n_step_sum / n_cell_cubed << std::endl;
         std::cout << "max number of steps: " << n_step_max << std::endl;
 
     }

--- a/unit_test/test_rhs/rhs_zones.H
+++ b/unit_test/test_rhs/rhs_zones.H
@@ -12,7 +12,6 @@
 #include <burner.H>
 #include <extern_parameters.H>
 #include <ArrayUtilities.H>
-#include <variables.H>
 
 using namespace unit_test_rp;
 


### PR DESCRIPTION
Along with #1287, this resolves all the remaining warnings I could find with `burn_cell` and `test_rhs`.