### PR TITLE
Add rhs_state to ener_gener_rate interface

### DIFF
--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -970,7 +970,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -970,7 +970,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -1840,7 +1840,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -1840,7 +1840,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -2024,7 +2024,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -2024,7 +2024,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/ignition_simple/actual_network.H
+++ b/networks/ignition_simple/actual_network.H
@@ -162,7 +162,7 @@ namespace RHS
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/ignition_simple/actual_network.H
+++ b/networks/ignition_simple/actual_network.H
@@ -162,7 +162,7 @@ namespace RHS
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -390,7 +390,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -390,7 +390,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/powerlaw/actual_network.H
+++ b/networks/powerlaw/actual_network.H
@@ -83,7 +83,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         if constexpr (spec == 2) {
             return dydt * NetworkProperties::aion(spec) * network_rp::specific_q_burn;

--- a/networks/powerlaw/actual_network.H
+++ b/networks/powerlaw/actual_network.H
@@ -83,7 +83,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         if constexpr (spec == 2) {
             return dydt * NetworkProperties::aion(spec) * network_rp::specific_q_burn;

--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -1369,11 +1369,11 @@ void rhs (burn_t& burn_state, Array1D<Real, 1, nrhs>& ydot)
         constexpr int species = n;
 
         if constexpr (nrhs == 2 * neqs) {
-            ydot(2 * net_ienuc - 1) += ener_gener_rate<species>(ydot(2 * species - 1));
-            ydot(2 * net_ienuc    ) += ener_gener_rate<species>(ydot(2 * species    ));
+            ydot(2 * net_ienuc - 1) += ener_gener_rate<species>(rhs_state, ydot(2 * species - 1));
+            ydot(2 * net_ienuc    ) += ener_gener_rate<species>(rhs_state, ydot(2 * species    ));
         }
         else {
-            ydot(net_ienuc) += ener_gener_rate<species>(ydot(species));
+            ydot(net_ienuc) += ener_gener_rate<species>(rhs_state, ydot(species));
         }
     });
 }
@@ -1516,14 +1516,14 @@ void jac (burn_t& burn_state, ArrayUtil::MathArray2D<1, neqs, 1, neqs>& jac)
         {
             constexpr int s = i;
 
-            jac(net_ienuc, species) += ener_gener_rate<s>(jac(s, species));
+            jac(net_ienuc, species) += ener_gener_rate<s>(rhs_state, jac(s, species));
         });
 
         // Convert previously computed terms from d/dT to d/de.
         jac(species, net_ienuc) = temperature_to_energy_jacobian(burn_state, jac(species, net_ienuc));
 
         // Compute df(e) / de term.
-        jac(net_ienuc, net_ienuc) += ener_gener_rate<species>(jac(species, net_ienuc));
+        jac(net_ienuc, net_ienuc) += ener_gener_rate<species>(rhs_state, jac(species, net_ienuc));
     });
 }
 

--- a/networks/triple_alpha_plus_cago/actual_network.H
+++ b/networks/triple_alpha_plus_cago/actual_network.H
@@ -177,7 +177,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
+    Real ener_gener_rate ([[maybe_unused]] const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }

--- a/networks/triple_alpha_plus_cago/actual_network.H
+++ b/networks/triple_alpha_plus_cago/actual_network.H
@@ -177,7 +177,7 @@ namespace RHS {
 
     template<int spec>
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    Real ener_gener_rate (Real const& dydt)
+    Real ener_gener_rate (const rhs_state_t& rhs_state, Real const& dydt)
     {
         return dydt * network::mion<spec>() * C::Legacy::enuc_conv2;
     }


### PR DESCRIPTION
This prepares for the conversion of ignition_chamulak, which determines the energy release based on the current density.