### PR TITLE
Convert rhs_t number of reactions from int to real

### DIFF
--- a/interfaces/rhs_type.H
+++ b/interfaces/rhs_type.H
@@ -45,12 +45,12 @@ struct rhs_t {
     int species_E{-1};
     int species_F{-1};
 
-    int number_A{0};
-    int number_B{0};
-    int number_C{0};
-    int number_D{0};
-    int number_E{0};
-    int number_F{0};
+    Real number_A{0.0_rt};
+    Real number_B{0.0_rt};
+    Real number_C{0.0_rt};
+    Real number_D{0.0_rt};
+    Real number_E{0.0_rt};
+    Real number_F{0.0_rt};
 
     int exponent_A{0};
     int exponent_B{0};

--- a/networks/aprox13/actual_network.H
+++ b/networks/aprox13/actual_network.H
@@ -189,8 +189,8 @@ namespace RHS {
             data.species_A = He4;
             data.species_D = C12;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 3;
             data.exponent_D = 1;
@@ -201,9 +201,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -215,9 +215,9 @@ namespace RHS {
             data.species_D = Ne20;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -230,10 +230,10 @@ namespace RHS {
             data.species_D = Mg24;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -248,9 +248,9 @@ namespace RHS {
             data.species_B = O16;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -269,9 +269,9 @@ namespace RHS {
             data.species_D = Si28;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -289,9 +289,9 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -312,8 +312,8 @@ namespace RHS {
             data.species_A = O16;
             data.species_D = S32;
 
-            data.number_A = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -330,9 +330,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -344,9 +344,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Mg24;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -363,9 +363,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -385,9 +385,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -407,9 +407,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -429,9 +429,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -451,9 +451,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -473,9 +473,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -495,9 +495,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -517,9 +517,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -535,10 +535,10 @@ namespace RHS {
             data.species_D = Al27;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -551,9 +551,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -566,10 +566,10 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -582,9 +582,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -597,10 +597,10 @@ namespace RHS {
             data.species_D = Cl35;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -613,9 +613,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -628,10 +628,10 @@ namespace RHS {
             data.species_D = K39;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -644,9 +644,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -659,10 +659,10 @@ namespace RHS {
             data.species_D = Sc43;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -675,9 +675,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -690,10 +690,10 @@ namespace RHS {
             data.species_D = V47;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -706,9 +706,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -721,10 +721,10 @@ namespace RHS {
             data.species_D = Mn51;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -737,9 +737,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -752,10 +752,10 @@ namespace RHS {
             data.species_D = Co55;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -768,9 +768,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;

--- a/networks/aprox19/actual_network.H
+++ b/networks/aprox19/actual_network.H
@@ -246,8 +246,8 @@ namespace RHS {
             data.species_A = P;
             data.species_D = N;
 
-            data.number_A = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -269,9 +269,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = H2;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -288,9 +288,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = He4;
 
-            data.number_A = 2;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_B = 2;
@@ -315,8 +315,8 @@ namespace RHS {
             data.species_A = H1;
             data.species_D = He3;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -333,8 +333,8 @@ namespace RHS {
             data.species_A = H1;
             data.species_D = He3;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -358,9 +358,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = He3;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -378,9 +378,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = He4;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -396,9 +396,9 @@ namespace RHS {
             data.species_D = He4;
             data.species_E = H1;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 2;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 2.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -413,10 +413,10 @@ namespace RHS {
             data.species_C = H1;
             data.species_D = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_C = 1;
-            data.number_D = 2;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_C = 1.0_rt;
+            data.number_D = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -443,9 +443,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = N13;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -458,9 +458,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = N14;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -479,9 +479,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -493,9 +493,9 @@ namespace RHS {
             data.species_D = Ne20;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -508,10 +508,10 @@ namespace RHS {
             data.species_D = Mg24;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -526,9 +526,9 @@ namespace RHS {
             data.species_B = O16;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -548,9 +548,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O15;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -563,9 +563,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -582,10 +582,10 @@ namespace RHS {
             data.species_D = C12;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -602,9 +602,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -627,10 +627,10 @@ namespace RHS {
             data.species_D = C12;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -654,9 +654,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = F18;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -670,9 +670,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 2;
-            data.number_B = 3;
-            data.number_D = 2;
+            data.number_A = 2.0_rt;
+            data.number_B = 3.0_rt;
+            data.number_D = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -692,9 +692,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = F17;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -708,10 +708,10 @@ namespace RHS {
             data.species_D = N14;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -731,9 +731,9 @@ namespace RHS {
             data.species_D = Si28;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -754,9 +754,9 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -767,8 +767,8 @@ namespace RHS {
             data.species_A = O16;
             data.species_D = S32;
 
-            data.number_A = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -788,9 +788,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -802,9 +802,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Mg24;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -816,9 +816,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -833,9 +833,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -850,9 +850,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -867,9 +867,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -884,9 +884,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -901,9 +901,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -918,9 +918,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -935,9 +935,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -954,10 +954,10 @@ namespace RHS {
             data.species_D = Al27;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -970,9 +970,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -985,10 +985,10 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1001,9 +1001,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1016,10 +1016,10 @@ namespace RHS {
             data.species_D = Cl35;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1032,9 +1032,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1047,10 +1047,10 @@ namespace RHS {
             data.species_D = K39;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1063,9 +1063,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1078,10 +1078,10 @@ namespace RHS {
             data.species_D = Sc43;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1094,9 +1094,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1109,10 +1109,10 @@ namespace RHS {
             data.species_D = V47;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1125,9 +1125,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1140,10 +1140,10 @@ namespace RHS {
             data.species_D = Mn51;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1156,9 +1156,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1171,10 +1171,10 @@ namespace RHS {
             data.species_D = Co55;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1187,9 +1187,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1201,9 +1201,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe53;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1218,9 +1218,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe54;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1235,9 +1235,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe54;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 2;
@@ -1259,9 +1259,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Co55;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1274,10 +1274,10 @@ namespace RHS {
             data.species_D = Fe54;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 2;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1301,9 +1301,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 2;
@@ -1325,8 +1325,8 @@ namespace RHS {
             data.species_A = Ni56;
             data.species_D = Fe54;
 
-            data.number_A = 54;
-            data.number_D = 56;
+            data.number_A = 54.0_rt;
+            data.number_D = 56.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;

--- a/networks/aprox21/actual_network.H
+++ b/networks/aprox21/actual_network.H
@@ -242,8 +242,8 @@ namespace RHS {
             data.species_A = P;
             data.species_D = N;
 
-            data.number_A = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -265,9 +265,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = H2;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -284,9 +284,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = He4;
 
-            data.number_A = 2;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_B = 2;
@@ -311,8 +311,8 @@ namespace RHS {
             data.species_A = H1;
             data.species_D = He3;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -329,8 +329,8 @@ namespace RHS {
             data.species_A = H1;
             data.species_D = He3;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -354,9 +354,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = He3;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -374,9 +374,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = He4;
 
-            data.number_A = 0;
-            data.number_B = 0;
-            data.number_D = 0;
+            data.number_A = 0.0_rt;
+            data.number_B = 0.0_rt;
+            data.number_D = 0.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -392,9 +392,9 @@ namespace RHS {
             data.species_D = He4;
             data.species_E = H1;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 2;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 2.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -409,10 +409,10 @@ namespace RHS {
             data.species_C = H1;
             data.species_D = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_C = 1;
-            data.number_D = 2;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_C = 1.0_rt;
+            data.number_D = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -426,8 +426,8 @@ namespace RHS {
             data.species_A = He4;
             data.species_D = C12;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 3;
             data.exponent_D = 1;
@@ -439,9 +439,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = N13;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -454,9 +454,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = N14;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -475,9 +475,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -489,9 +489,9 @@ namespace RHS {
             data.species_D = Ne20;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -504,10 +504,10 @@ namespace RHS {
             data.species_D = Mg24;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -522,9 +522,9 @@ namespace RHS {
             data.species_B = O16;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -544,9 +544,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O15;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -559,9 +559,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -578,10 +578,10 @@ namespace RHS {
             data.species_D = C12;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -598,9 +598,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -623,10 +623,10 @@ namespace RHS {
             data.species_D = C12;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -650,9 +650,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = F18;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -666,9 +666,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 2;
-            data.number_B = 3;
-            data.number_D = 2;
+            data.number_A = 2.0_rt;
+            data.number_B = 3.0_rt;
+            data.number_D = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -688,9 +688,9 @@ namespace RHS {
             data.species_B = H1;
             data.species_D = F17;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -704,10 +704,10 @@ namespace RHS {
             data.species_D = N14;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -727,9 +727,9 @@ namespace RHS {
             data.species_D = Si28;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -750,9 +750,9 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -763,8 +763,8 @@ namespace RHS {
             data.species_A = O16;
             data.species_D = S32;
 
-            data.number_A = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -784,9 +784,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -798,9 +798,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Mg24;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -812,9 +812,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -829,9 +829,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -846,9 +846,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -863,9 +863,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -880,9 +880,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -897,9 +897,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -914,9 +914,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -931,9 +931,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -950,10 +950,10 @@ namespace RHS {
             data.species_D = Al27;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -966,9 +966,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -981,10 +981,10 @@ namespace RHS {
             data.species_D = P31;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -997,9 +997,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = S32;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1012,10 +1012,10 @@ namespace RHS {
             data.species_D = Cl35;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1028,9 +1028,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ar36;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1043,10 +1043,10 @@ namespace RHS {
             data.species_D = K39;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1059,9 +1059,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ca40;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1074,10 +1074,10 @@ namespace RHS {
             data.species_D = Sc43;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1090,9 +1090,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1105,10 +1105,10 @@ namespace RHS {
             data.species_D = V47;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1121,9 +1121,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Cr48;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1136,10 +1136,10 @@ namespace RHS {
             data.species_D = Mn51;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1152,9 +1152,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Fe52;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1167,10 +1167,10 @@ namespace RHS {
             data.species_D = Co55;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1183,9 +1183,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1197,9 +1197,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe53;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1214,9 +1214,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe54;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1231,9 +1231,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe54;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 2;
@@ -1255,9 +1255,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Co55;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1270,10 +1270,10 @@ namespace RHS {
             data.species_D = Fe54;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 2;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1297,9 +1297,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 2;
@@ -1321,8 +1321,8 @@ namespace RHS {
             data.species_A = Ni56;
             data.species_D = Fe56;
 
-            data.number_A = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -1337,8 +1337,8 @@ namespace RHS {
             data.species_A = Fe56;
             data.species_D = Cr56;
 
-            data.number_A = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_D = 1;
@@ -1356,9 +1356,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe55;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1373,9 +1373,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe56;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1390,9 +1390,9 @@ namespace RHS {
             data.species_B = N;
             data.species_D = Fe56;
 
-            data.number_A = 1;
-            data.number_B = 2;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 2;
@@ -1415,10 +1415,10 @@ namespace RHS {
             data.species_D = Co57;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1431,9 +1431,9 @@ namespace RHS {
             data.species_B = P;
             data.species_D = Co57;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -1446,10 +1446,10 @@ namespace RHS {
             data.species_D = Fe56;
             data.species_E = P;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 2;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 2.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;

--- a/networks/ignition_simple/actual_network.H
+++ b/networks/ignition_simple/actual_network.H
@@ -123,8 +123,8 @@ namespace RHS
             data.species_A = C12;
             data.species_D = Mg24;
 
-            data.number_A = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -148,8 +148,8 @@ namespace RHS {
             data.species_A = He4;
             data.species_D = C12;
 
-            data.number_A = 3.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 3;
             data.exponent_D = 1;
@@ -160,9 +160,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -174,9 +174,9 @@ namespace RHS {
             data.species_D = Ne20;
             data.species_E = He4;
 
-            data.number_A = 2.0_rt
-            data.number_D = 1.0_rt
-            data.number_E = 1.0_rt
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -189,10 +189,10 @@ namespace RHS {
             data.species_D = Mg24;
             data.species_E = He4;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
-            data.number_E = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -208,9 +208,9 @@ namespace RHS {
             data.species_B = O16;
             data.species_D = Si28;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -225,9 +225,9 @@ namespace RHS {
             data.species_D = Si28;
             data.species_E = He4;
 
-            data.number_A = 2.0_rt
-            data.number_D = 1.0_rt
-            data.number_E = 1.0_rt
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
+            data.number_E = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -239,9 +239,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -253,9 +253,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Mg24;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -267,9 +267,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Si28;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -281,9 +281,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ti44;
 
-            data.number_A = 1.0_rt
-            data.number_B = 1.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -295,9 +295,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ni56;
 
-            data.number_A = 1.0_rt
-            data.number_B = 7.0_rt
-            data.number_D = 1.0_rt
+            data.number_A = 1.0_rt;
+            data.number_B = 7.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;

--- a/networks/iso7/actual_network.H
+++ b/networks/iso7/actual_network.H
@@ -148,8 +148,8 @@ namespace RHS {
             data.species_A = He4;
             data.species_D = C12;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 3;
             data.exponent_D = 1;
@@ -160,9 +160,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -174,9 +174,9 @@ namespace RHS {
             data.species_D = Ne20;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt
+            data.number_D = 1.0_rt
+            data.number_E = 1.0_rt
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -189,10 +189,10 @@ namespace RHS {
             data.species_D = Mg24;
             data.species_E = He4;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
+            data.number_E = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -208,9 +208,9 @@ namespace RHS {
             data.species_B = O16;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -225,9 +225,9 @@ namespace RHS {
             data.species_D = Si28;
             data.species_E = He4;
 
-            data.number_A = 2;
-            data.number_D = 1;
-            data.number_E = 1;
+            data.number_A = 2.0_rt
+            data.number_D = 1.0_rt
+            data.number_E = 1.0_rt
 
             data.exponent_A = 2;
             data.exponent_D = 1;
@@ -239,9 +239,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ne20;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -253,9 +253,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Mg24;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -267,9 +267,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Si28;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -281,9 +281,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ti44;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 1.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;
@@ -295,9 +295,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = Ni56;
 
-            data.number_A = 1;
-            data.number_B = 7;
-            data.number_D = 1;
+            data.number_A = 1.0_rt
+            data.number_B = 7.0_rt
+            data.number_D = 1.0_rt
 
             data.exponent_A = 1;
             data.exponent_B = 1;

--- a/networks/powerlaw/actual_network.H
+++ b/networks/powerlaw/actual_network.H
@@ -39,8 +39,8 @@ namespace RHS {
             data.species_A = Fuel;
             data.species_D = Ash;
 
-            data.number_A = 2;
-            data.number_D = 1;
+            data.number_A = 2.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 2;
             data.exponent_D = 1;

--- a/networks/triple_alpha_plus_cago/actual_network.H
+++ b/networks/triple_alpha_plus_cago/actual_network.H
@@ -117,8 +117,8 @@ namespace RHS {
             data.species_A = He4;
             data.species_D = C12;
 
-            data.number_A = 3;
-            data.number_D = 1;
+            data.number_A = 3.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 3;
             data.exponent_D = 1;
@@ -132,9 +132,9 @@ namespace RHS {
             data.species_B = He4;
             data.species_D = O16;
 
-            data.number_A = 1;
-            data.number_B = 1;
-            data.number_D = 1;
+            data.number_A = 1.0_rt;
+            data.number_B = 1.0_rt;
+            data.number_D = 1.0_rt;
 
             data.exponent_A = 1;
             data.exponent_B = 1;

--- a/sphinx_docs/source/templated_networks.rst
+++ b/sphinx_docs/source/templated_networks.rst
@@ -117,9 +117,9 @@ For example, consider the reaction :math:`\isotm{He}{4} + \isotm{C}{12} \rightar
    data.species_B = He4;
    data.species_D = O16;
 
-   data.number_A = 1;
-   data.number_B = 1;
-   data.number_D = 1;
+   data.number_A = 1.0_rt;
+   data.number_B = 1.0_rt;
+   data.number_D = 1.0_rt;
 
    data.exponent_A = 1;
    data.exponent_B = 1;
@@ -149,10 +149,10 @@ special cases (e.g., for approximate nets):
           data.species_D = Mg24;
           data.species_E = He4;
 
-          data.number_A = 1;
-          data.number_B = 1;
-          data.number_D = 1;
-          data.number_E = 1;
+          data.number_A = 1.0_rt;
+          data.number_B = 1.0_rt;
+          data.number_D = 1.0_rt;
+          data.number_E = 1.0_rt;
 
           data.exponent_A = 1;
           data.exponent_B = 1;
@@ -167,9 +167,9 @@ special cases (e.g., for approximate nets):
           data.species_B = O16;
           data.species_D = Si28;
 
-          data.number_A = 1;
-          data.number_B = 1;
-          data.number_D = 1;
+          data.number_A = 1.0_rt;
+          data.number_B = 1.0_rt;
+          data.number_D = 1.0_rt;
 
           data.exponent_A = 1;
           data.exponent_B = 1;
@@ -278,9 +278,9 @@ special cases (e.g., for approximate nets):
          data.species_B = He4;
          data.species_D = Si28;
 
-         data.number_A = 1;
-         data.number_B = 1;
-         data.number_D = 1;
+         data.number_A = 1.0_rt;
+         data.number_B = 1.0_rt;
+         data.number_D = 1.0_rt;
 
          data.exponent_A = 1;
          data.exponent_B = 1;


### PR DESCRIPTION
This supports conversion of ignition_chamulak to the new reactions scheme. It should also allow replacement of the branching ratio, at least in some cases, with a direct modification to the number of reactants consumed.