### PR TITLE
Switch to a simpler pynucastro net for HIP CI

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -34,8 +34,8 @@ jobs:
           cd unit_test/test_react
           make COMP=gnu USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=aprox13 -j 2
 
-      - name: compile test_react with HIP (subch_simple)
+      - name: compile test_react with HIP (ignition_reaclib/URCA-simple)
         run: |
           cd unit_test/test_react
           make realclean
-          make COMP=gnu USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=subch_simple -j 2
+          make COMP=gnu USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple -j 2


### PR DESCRIPTION
subch_simple takes nearly an hour to link, so it's suboptimal as a CI test. This ensures we still have pynucastro coverage but is significantly faster.