### PR TITLE
Remove d(rate)/dY terms in rprox Jacobian

### DIFF
--- a/networks/rprox/actual_rhs.H
+++ b/networks/rprox/actual_rhs.H
@@ -179,7 +179,6 @@ void make_rates (const Real& T9, const Real& dens, Array1D<Real, 1, NumSpec>& y,
                                         rate * dens * sc1a * y(H1));
     if (rr(1).rates(irlambCNO) < rr(1).rates(irwk15o)) {
         rr(2).rates(irlambCNO) = dens * y(H1) * (dratedt * sc1a + rate * sc1adt);
-        rr(3).rates(dlambCNOdh1) = rate * dens * sc1a;
     }
 
     // 22mg(...)30s
@@ -197,7 +196,6 @@ void make_rates (const Real& T9, const Real& dens, Array1D<Real, 1, NumSpec>& y,
                                         dens * y(He4) * rate * sc1a);
     if (rr(1).rates(irlambda1) > rr(1).rates(irLweak)) {
         rr(2).rates(irlambda1) = dens * y(He4) * (dratedt * sc1a + rate *  sc1adt);
-        rr(3).rates(dlambda1dhe4) = dens * rate * sc1a;
         // use the sign of state.rates(1, irlambda1) to indicate the value of delta1 in WW81
         // if delta1 = 1, then we multiply the rate by -1
         rr(1).rates(irlambda1) = -1.0_rt * rr(1).rates(irlambda1);
@@ -218,7 +216,6 @@ void make_rates (const Real& T9, const Real& dens, Array1D<Real, 1, NumSpec>& y,
                                         dens * y(He4) * rate * sc1a);
     if (rr(1).rates(irlambda2) > rr(1).rates(irla2)) {
         rr(2).rates(irlambda2) = dens * y(He4) * (dratedt * sc1a + rate * sc1adt);
-        rr(3).rates(dlambda2dhe4) = dens * rate * sc1a;
         // use the sign of rr(1).rates(irlambda2) to indicate the value of delta2
         // if delta2 = 1, then we multiply the rate by -1
         rr(1).rates(irlambda2) = -1.0_rt * rr(1).rates(irlambda2);
@@ -237,8 +234,6 @@ void make_rates (const Real& T9, const Real& dens, Array1D<Real, 1, NumSpec>& y,
     rr(1).rates(irs1) = wk18ne / (wk18ne + dens * y(He4) * rate * sc1a);
     rr(2).rates(irs1) = -rr(1).rates(irs1) * dens * y(He4) * (dratedt * sc1a + rate * sc1adt)
                          / (wk18ne + dens * y(He4) * rate * sc1a);
-    rr(3).rates(drs1dhe4) = -rr(1).rates(irs1) * dens * rate * sc1a
-                             / (wk18ne + dens * y(He4) * rate * sc1a);
 
     // form r1 from WW81; ranching ratio for 19ne beta decay (wk19ne) vs (p,g)
     // store result in irr1
@@ -253,8 +248,6 @@ void make_rates (const Real& T9, const Real& dens, Array1D<Real, 1, NumSpec>& y,
     rr(1).rates(irr1) = wk19ne / (wk19ne + dens * y(H1) * rate * sc1a);
     rr(2).rates(irr1) = -rr(1).rates(irr1) * dens * y(H1) * (dratedt * sc1a + rate * sc1adt)
                          / (wk19ne + dens * y(H1) * rate * sc1a);
-    rr(3).rates(drr1dh1) = -rr(1).rates(irr1) * dens * rate * sc1a
-                            / (wk19ne + dens * y(H1) * rate * sc1a);
 
 
     //....

--- a/unit_test/test_rhs/ci-benchmarks/rprox.out
+++ b/unit_test/test_rhs/ci-benchmarks/rprox.out
@@ -114,26 +114,26 @@
  J_E_nickel-56                               0                      0
  J_carbon-12_helium-4          7.314141482e-32           142926.91777
  J_oxygen-14_helium-4             -56717144756      -2.7938921413e-29
- J_oxygen-15_helium-4            -9737803.5071      -9.2918568894e-34
+ J_oxygen-15_helium-4            -9737803.5067      -9.2918568866e-34
  J_oxygen-16_helium-4            -5332924.3385       3.0455688646e-07
  J_flourine-17_helium-4       2.7938921413e-29            56717144756
- J_magnesium-22_helium-4           -23891379754            2471145.424
- J_sulfur-30_helium-4                        0            22917545851
- J_nickel-56_helium-4                        0           984025417.26
+ J_magnesium-22_helium-4       5.1593490705e-35           12230353.705
+ J_sulfur-30_helium-4                        0                      0
+ J_nickel-56_helium-4                        0                      0
  J_helium-4_helium-4              -56727337313      -2.8993248893e-29
- J_hydrogen-1_helium-4       -1.6010532786e+11           3284595971.1
- J_E_helium-4                 3.3676822941e-11       2.0257660358e+30
- J_carbon-12_hydrogen-1           -26899767827      -2.2647400918e-06
+ J_hydrogen-1_helium-4           -51.975833656            56691903136
+ J_E_helium-4                 3.3676822941e-11       6.5461989995e+28
+ J_carbon-12_hydrogen-1           -26899767827      -2.2682476973e-06
  J_oxygen-14_hydrogen-1       2.2682476973e-06            26899767827
- J_oxygen-15_hydrogen-1      -0.00024222000826           1695.5964262
+ J_oxygen-15_hydrogen-1       4.4616969386e-12           1695.5964262
  J_oxygen-16_hydrogen-1          -723321717.93      -3.3173023263e-10
  J_flourine-17_hydrogen-1          -14133036.661           533399243.58
- J_magnesium-22_hydrogen-1       2.1616356901e-44           189922474.35
+ J_magnesium-22_hydrogen-1                      0           189922474.35
  J_sulfur-30_hydrogen-1                      0                      0
  J_nickel-56_hydrogen-1                      0                      0
- J_helium-4_hydrogen-1           -189922474.35           927.47530764
- J_hydrogen-1_hydrogen-1           -53877537415      -4.5403436538e-06
- J_E_hydrogen-1                1.440700152e+13       1.7081017075e+29
+ J_helium-4_hydrogen-1           -189922474.35           927.47530774
+ J_hydrogen-1_hydrogen-1           -53877537415      -4.5368360483e-06
+ J_E_hydrogen-1               1.4378228394e+13       1.7081017075e+29
  J_carbon-12_E                    -63.63763642           0.9574584339
  J_oxygen-14_E                   -16.885124406           63.634574488
  J_oxygen-15_E                -0.0078799579401        0.0012865310157


### PR DESCRIPTION
These will not be supportable in the new reactions scheme, so they are pre-emptively removed.