### PR TITLE
Add has_G to check if G is in the EOS type

### DIFF
--- a/EOS/gamma_law/actual_eos.H
+++ b/EOS/gamma_law/actual_eos.H
@@ -265,7 +265,9 @@ void actual_eos (I input, T& state)
 
             // sound speed
             state.cs = std::sqrt(eos_gamma * state.p * rhoinv);
-            state.G = 0.5 * (1.0 + eos_gamma);
+            if constexpr (has_G<T>::value) {
+                state.G = 0.5 * (1.0 + eos_gamma);
+            }
         }
     }
 

--- a/EOS/primordial_chem/actual_eos.H
+++ b/EOS/primordial_chem/actual_eos.H
@@ -278,7 +278,9 @@ void actual_eos (I input, T& state)
         state.dpdT = pressure / temp;
         state.dpdr = pressure / dens;
         state.cs = std::sqrt((1.0 + 1.0/sum_gammasinv) * state.p /state.rho);
-        state.G = 0.5 * (1.0 + (1.0 + 1.0/sum_gammasinv));
+        if constexpr (has_G<T>::value) {
+            state.G = 0.5 * (1.0 + (1.0 + 1.0/sum_gammasinv));
+        }
     }
 
     Real dedT = sum_gammasinv * sum_Abarinv * gasconstant;

--- a/interfaces/eos_type.H
+++ b/interfaces/eos_type.H
@@ -199,6 +199,14 @@ struct has_dpdA<T, decltype((void)T::dpdA, void())>
     : std::true_type {};
 
 template <typename T, typename Enable = void>
+struct has_G
+    : std::false_type {};
+
+template <typename T>
+struct has_G<T, decltype((void)T::G, void())>
+    : std::true_type {};
+
+template <typename T, typename Enable = void>
 struct has_dpdZ
     : std::false_type {};
 


### PR DESCRIPTION
This fixes invocations of gamma_law with types other than eos_t.