### PR TITLE
CMake: do not generate network_properties twice

### DIFF
--- a/.github/workflows/cmake_build_cell_primordial_chem.yml
+++ b/.github/workflows/cmake_build_cell_primordial_chem.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Compile and run
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMREX=true
+          cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMReX=true
           make -j2
           ctest --output-on-failure

--- a/.github/workflows/macos_build_cell_primordial_chem.yml
+++ b/.github/workflows/macos_build_cell_primordial_chem.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Compile and run
         run: |
           mkdir build && cd build
-          cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMREX=true
+          cmake .. -DBUILD_UNIT_TEST=true -DBUILD_AMReX=true
           make -j2
           ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
 
 
     #below to update headers
-    execute_process(COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTHONPATH}:${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null" python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/update_headers.py" --net "${networkdir}" --microphysics_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/" --odir "${output_dir}" WORKING_DIRECTORY ${output_dir}/)
+    #execute_process(COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTHONPATH}:${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null" python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/update_headers.py" --net "${networkdir}" --microphysics_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/" --odir "${output_dir}" WORKING_DIRECTORY ${output_dir}/)
     #below for NAUX
     execute_process(COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTHONPATH}:${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null" python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/get_naux.py" --net "${networkdir}" --microphysics_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/" WORKING_DIRECTORY ${output_dir}/)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,6 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
                                 ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
 
 
-    #below to update headers
-    #execute_process(COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTHONPATH}:${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null" python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/update_headers.py" --net "${networkdir}" --microphysics_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/" --odir "${output_dir}" WORKING_DIRECTORY ${output_dir}/)
     #below for NAUX
     execute_process(COMMAND ${CMAKE_COMMAND} -E env "PYTHONPATH=${PYTHONPATH}:${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null" python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/get_naux.py" --net "${networkdir}" --microphysics_path "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/" WORKING_DIRECTORY ${output_dir}/)
 
@@ -103,17 +101,17 @@ endfunction()
 
 #set a cache variable that controls whether
 #we want to fetch and link amrex or not
-set(BUILD_AMREX false CACHE BOOL "Do you want to build and link amrex? (true/false)")
-message("Building and linking amrex -- ${BUILD_AMREX}")
+set(BUILD_AMReX false CACHE BOOL "Do you want to build and link amrex? (true/false)")
+message("Building and linking amrex -- ${BUILD_AMReX}")
 
-if(BUILD_AMREX)
+if(BUILD_AMReX)
    #fetching amrex
-   set (AMREX_TAG "development")
+   set (AMReX_TAG "development")
    include(FetchContent)
    FetchContent_Declare(
      amrex
      GIT_REPOSITORY https://github.com/AMReX-Codes/amrex
-     GIT_TAG "${AMREX_TAG}"
+     GIT_TAG "${AMReX_TAG}"
    )
 
    # CMake 3.14+


### PR DESCRIPTION
We were generating `network_properties.H` for primordial chem twice. 

Also changed AMReX related variable names to use lowercase 'e'