### PR TITLE
Constrain Sphinx version to fix docs build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-Sphinx
+# breathe is incompatible with Sphinx 7.2
+# waiting on https://github.com/breathe-doc/breathe/issues/943 to be fixed
+Sphinx<7.2.0
 sphinx_rtd_theme
 breathe
 sphinxcontrib_bibtex


### PR DESCRIPTION
Breathe is currently incompatible with Sphinx >= 7.2: see https://github.com/breathe-doc/breathe/issues/943.