### PR TITLE
don't allow logical runtime parameters

### DIFF
--- a/EOS/gamma_law/_parameters
+++ b/EOS/gamma_law/_parameters
@@ -1,4 +1,4 @@
 @namespace: eos
 
 eos_gamma            real     5.d0/3.d0
-eos_assume_neutral   logical  .true.
+eos_assume_neutral   integer  1

--- a/EOS/helmholtz/_parameters
+++ b/EOS/helmholtz/_parameters
@@ -1,10 +1,10 @@
 @namespace: eos
 
 # use the Coulomb corrections
-use_eos_coulomb                     logical            .true.
+use_eos_coulomb                     integer            1
 
 # Force the EOS output quantities to match input
-eos_input_is_constant               logical            .true.
+eos_input_is_constant               integer            1
 
 # Tolerance for iterations with respect to temperature
 eos_ttol                            real               1.0d-8

--- a/Make.Microphysics
+++ b/Make.Microphysics
@@ -153,7 +153,6 @@ endif
 EXTERN_PARAMETERS := $(shell $(MICROPHYSICS_HOME)/util/build_scripts/findparams.py $(EXTERN_SEARCH))
 
 
-$(MICROPHYSICS_AUTO_SOURCE_DIR)/extern.F90: $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.H
 $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.cpp: $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.H
 
 $(MICROPHYSICS_AUTO_SOURCE_DIR)/extern_parameters.H: $(EXTERN_PARAMETERS) $(EXTERN_TEMPLATE)

--- a/integration/_parameters
+++ b/integration/_parameters
@@ -6,10 +6,10 @@
 # the current internal energy. This is done with an EOS call, which can
 # be turned off if desired. This will freeze the temperature and specific heat
 # to the values at the beginning of the burn, which is inaccurate but cheaper.
-call_eos_in_rhs          logical   .true.
+call_eos_in_rhs          integer   1
 
 # Allow the energy integration to be disabled by setting the RHS to zero.
-integrate_energy         logical   .true.
+integrate_energy         integer   1
 
 # Whether to use an analytical or numerical Jacobian.
 # 1 == Analytical
@@ -18,7 +18,7 @@ integrate_energy         logical   .true.
 jacobian                 integer   1
 
 # Should we print out diagnostic output after the solve?
-burner_verbose           logical   .false.
+burner_verbose           integer   0
 
 # Tolerances for the solver (relative and absolute), for the
 # species and energy equations.
@@ -30,7 +30,7 @@ atol_enuc                real      1.d-6
 
 # Whether to renormalize the mass fractions at each step in the evolution
 # so that they sum to unity.
-renormalize_abundances   logical   .false.
+renormalize_abundances   integer   0
 
 # The absolute cutoff for species -- note that this might be larger
 # than ``small_x``, but the issue is that we need to prevent underflow
@@ -51,7 +51,7 @@ ode_max_steps              integer      150000
 ode_max_dt                 real         1.d30
 
 # Whether to use Jacobian caching in VODE
-use_jacobian_caching    logical   .true.
+use_jacobian_caching    integer    1
 
 # Inputs for generating a Nonaka Plot (TM)
 nonaka_i                integer           0
@@ -65,10 +65,10 @@ nonaka_file             character         "nonaka_plot.dat"
 do_species_clip              integer          1
 
 # flag for turning on the use of number densities for all species
-use_number_densities     logical          .false.
+use_number_densities     integer     0
 
 # flag for tuning on the subtraction of internal energy
-subtract_internal_energy   logical       .true.
+subtract_internal_energy   integer     1
 
 # SDC iteration tolerance adjustment factor
 sdc_burn_tol_factor          real         1.d0

--- a/networks/_parameters
+++ b/networks/_parameters
@@ -4,7 +4,7 @@
 small_x                              real               1.d-30
 
 # Should we use rate tables if they are present in the network?
-use_tables  logical   .false.
+use_tables                           integer            0
 
 # Should we use Deboer + 2017 rate for c12(a,g)o16?
-use_c12ag_deboer17  logical   .false.
+use_c12ag_deboer17                   integer            0

--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -3,7 +3,7 @@
 max_nse_iters           integer    500
 use_hybrid_solver       integer    1
 ase_tol                 real       0.1
-nse_dx_independent      logical    .false.
-nse_molar_independent   logical    .false.
-nse_skip_molar          logical    .false.
+nse_dx_independent      integer    0
+nse_molar_independent   integer    0
+nse_skip_molar          integer    0
 T_nse_net               real       -1.0

--- a/util/build_scripts/write_probin.py
+++ b/util/build_scripts/write_probin.py
@@ -7,7 +7,6 @@ is:
 max_step                            integer            1
 small_dt                            real               1.d-10
 xlo_boundary_type                   character          ""
-octant                              logical            .false.
 
 This specifies the runtime parameter name, datatype, and default
 value.
@@ -106,6 +105,11 @@ def parse_param_file(params_list, param_file, use_namespace=False):
         name = fields[0]
         dtype = fields[1]
         default = fields[2]
+
+        if dtype == "logical":
+            print("write_probin.py: ERROR: logical type no longer supported in _parameter files.")
+            err = 1
+            continue
 
         if use_namespace:
             skip_namespace_in_declare = False


### PR DESCRIPTION
when we originally did the Fortran -> C++ conversion, we passed all of the Fortran logicals into C++ ints.  But now that we are completely C++, it doesn't make sense to have logical anymore.  There are some places where we implicitly pass an int to a C++ bool.  This will help track those down and eliminate things.