### PR TITLE
Update C++ linter settings to speed up cppcheck

### DIFF
--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -28,13 +28,15 @@ jobs:
           sudo apt-get -qq -y install curl clang-tidy cmake jq clang cppcheck clang-format bear g++>=9.3.0
 
       - name: Run cpp linter
-        uses: AMReX-Astro/cpp-linter-action@main
+        uses: yut23/cpp-linter-action@cppcheck-improvements
         with:
           build_path: 'unit_test/test_react'
           make_options: '-j 2 USE_OMP=FALSE USE_MPI=FALSE USE_CUDA=FALSE DEBUG=TRUE'
-          ignore_files: 'amrex'
+          ignore_files: 'amrex|util/gcem'
           header_filter: '(/conductivity/|/constants/|/EOS/|/integration/|/interfaces/|/networks/|/neutrinos/|/nse_solver/|/opacity/|/rates/|/screening/|/util/|^\./).*\.H$'
           config_file: ${GITHUB_WORKSPACE}/.clang-tidy
+          # not sure why cppcheck tests _MSC_VER, since it's only referenced from gcem
+          cppcheck_options: '-U_OPENMP -UAMREX_USE_GPU -UAMREX_USE_CUDA -UAMREX_USE_HIP -U_MSC_VER'
 
       - name: Archive clang tidy report
         uses: actions/upload-artifact@v1

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -22,11 +22,6 @@ jobs:
           if [[ -n "${AMREX_HOME}" ]]; then exit 1; fi
           cd ../..
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update -y -qq
-          sudo apt-get -qq -y install curl clang-tidy cmake jq clang cppcheck clang-format bear g++>=9.3.0
-
       - name: Run cpp linter
         uses: yut23/cpp-linter-action@cppcheck-improvements
         with:

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -23,7 +23,7 @@ jobs:
           cd ../..
 
       - name: Run cpp linter
-        uses: yut23/cpp-linter-action@cppcheck-improvements
+        uses: AMReX-Astro/cpp-linter-action@main
         with:
           build_path: 'unit_test/test_react'
           make_options: '-j 2 USE_OMP=FALSE USE_MPI=FALSE USE_CUDA=FALSE DEBUG=TRUE'


### PR DESCRIPTION
We were previously testing a bunch of invalid preprocessor configurations, which we can now exclude. Installing all the build tools is unnecessary since the linter step runs inside its own Docker container.