### PR TITLE
add additional molar fraction check for NSE_NET

### DIFF
--- a/nse_solver/_parameters
+++ b/nse_solver/_parameters
@@ -3,6 +3,8 @@
 max_nse_iters           integer    500
 use_hybrid_solver       integer    1
 ase_tol                 real       0.1
+nse_abs_tol             real       0.005
+nse_rel_tol             real       0.2
 nse_dx_independent      integer    0
 nse_molar_independent   integer    0
 nse_skip_molar          integer    0

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -68,6 +68,17 @@ void check_nse_molar(burn_t& state, const burn_t& nse_state, bool& nse_check) {
   if ((std::abs((r - r_nse) / r_nse) < 0.25_rt) && (NSE_INDEX::N_index == -1)) {
     nse_check = true;
   }
+
+  // Overall molar fraction check
+
+  for (int n = 1; n < NumSpec; ++n) {
+      Real abs_diff = std::abs(state.xn[n] - nse_state.xn[n]) / aion[n];
+      Real rel_diff = abs_diff / (state.xn[n] / aion[n]);
+      if (abs_diff > 0.005 && rel_diff > 0.2) {
+          return;
+      }
+  }
+  nse_check=true;
 }
 
 
@@ -302,7 +313,6 @@ void find_fast_reaction_cycle(const int current_nuc_ind, const amrex::Array1D<am
 
     if (!have_required_nucs) {
       found_fast_reaction_cycle = false;
-
       return;
     }
   }

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -80,7 +80,7 @@ void check_nse_molar(burn_t& state, const burn_t& nse_state, bool& nse_check) {
           return;
       }
   }
-  nse_check=true;
+  nse_check = true;
 }
 
 

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -73,10 +73,10 @@ void check_nse_molar(burn_t& state, const burn_t& nse_state, bool& nse_check) {
 
   // Overall molar fraction check
 
-  for (int n = 1; n < NumSpec; ++n) {
+  for (int n = 0; n < NumSpec; ++n) {
       Real abs_diff = std::abs(state.xn[n] - nse_state.xn[n]) / aion[n];
       Real rel_diff = abs_diff / (state.xn[n] / aion[n]);
-      if (abs_diff > 0.005 && rel_diff > 0.2) {
+      if (abs_diff > nse_abs_tol && rel_diff > nse_rel_tol) {
           return;
       }
   }

--- a/nse_solver/nse_check.H
+++ b/nse_solver/nse_check.H
@@ -61,12 +61,14 @@ void check_nse_molar(burn_t& state, const burn_t& nse_state, bool& nse_check) {
 
   if ((std::abs((r - r_nse) / r_nse) < 0.5_rt) && (NSE_INDEX::N_index != -1)) {
     nse_check = true;
+    return;
   }
 
   // if there is no neutron in the network
 
   if ((std::abs((r - r_nse) / r_nse) < 0.25_rt) && (NSE_INDEX::N_index == -1)) {
     nse_check = true;
+    return;
   }
 
   // Overall molar fraction check

--- a/sphinx_docs/source/nse.rst
+++ b/sphinx_docs/source/nse.rst
@@ -356,6 +356,16 @@ nse check:
   Note that we still perform a simple molar fraction check to ensure that the current state
   is close enough to the NSE state.
 
+* ``nse.ase_tol`` is the tolerance that determines the equilibrium condition for forward
+  and reverse rates. This is set to 0.1 by default.
+
+* ``nse.nse_abs_tol`` is the absolute tolerance of checking the difference between current
+  molar fraction and the NSE molar fraction. This is set to 0.005 by default.
+
+* ``nse.nse_rel_tol`` is the absolute tolerance of checking the difference between current
+  molar fraction and the NSE molar fraction. This is set to 0.005 by default.
+
+
 .. rubric:: Footnotes
 
 .. [#fY] The table actually provides the weak rate, which is the sum
@@ -365,4 +375,3 @@ nse check:
 
    So if electron capture dominates, then [wrate] is positive and this should
    be subtracted from :math:`Y_e`.
-

--- a/sphinx_docs/source/nse.rst
+++ b/sphinx_docs/source/nse.rst
@@ -362,8 +362,8 @@ nse check:
 * ``nse.nse_abs_tol`` is the absolute tolerance of checking the difference between current
   molar fraction and the NSE molar fraction. This is set to 0.005 by default.
 
-* ``nse.nse_rel_tol`` is the absolute tolerance of checking the difference between current
-  molar fraction and the NSE molar fraction. This is set to 0.005 by default.
+* ``nse.nse_rel_tol`` is the relative tolerance of checking the difference between current
+  molar fraction and the NSE molar fraction. This is set to 0.2 by default.
 
 
 .. rubric:: Footnotes


### PR DESCRIPTION
I was playing around with the NSE compatibility script and found the original molar fraction check a bit too strict, where the mass fractions might be already sufficient for the forward and reverse equilibrium conditions but still don't pass the molar fraction check.

Here I added another one comparing the molar fraction of each species.