### PR TITLE
fix a loop bound in the templated rhs.H linear algebra

### DIFF
--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -307,7 +307,7 @@ void dgesl (RArray2D& a1, RArray1D& b1)
         b(k) = b(k) / a(k,k);
         Real t = -b(k);
 
-        constexpr_for<0, k>([&] (auto j)
+        constexpr_for<0, k-1>([&] (auto j)
         {
             if (is_jacobian_term_used<j, k>()) {
                 b(j) += t * a(j,k);


### PR DESCRIPTION
If we compare to `util/linpack.H`, then the inner loop in dgesl where we are 
solving u * x = y should go from: 1 <= j <= k-1, so when we shift to 0-based indexing,
it should be 0 <= j <= k-2, or `constexper_for<0, k-1>`