### PR TITLE
Don't force-inline actual_integrator()

### DIFF
--- a/integration/BackwardEuler/actual_integrator.H
+++ b/integration/BackwardEuler/actual_integrator.H
@@ -5,7 +5,7 @@
 #include <be_integrator.H>
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, const Real dt, bool is_retry=false)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();

--- a/integration/BackwardEuler/actual_integrator_sdc.H
+++ b/integration/BackwardEuler/actual_integrator_sdc.H
@@ -9,7 +9,7 @@
 #include <integrator_data.H>
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, const Real dt, bool is_retry=false)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();

--- a/integration/ForwardEuler/actual_integrator.H
+++ b/integration/ForwardEuler/actual_integrator.H
@@ -156,7 +156,7 @@ void initialize_int_state (IntT& int_state)
 }
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, Real dt, bool is_retry=false)
 {
     using namespace microphysics::forward_euler;

--- a/integration/QSS/actual_integrator.H
+++ b/integration/QSS/actual_integrator.H
@@ -196,7 +196,7 @@ bool corrector (const BurnT& state_0, const Array1D<Real, 1, NumSpec>& f_minus_0
 }
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, Real dt, const bool is_retry=false)
 {
     initialize_state(state);

--- a/integration/RKC/actual_integrator.H
+++ b/integration/RKC/actual_integrator.H
@@ -12,7 +12,7 @@
 #include <rkc.H>
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, Real dt, bool is_retry=false)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();

--- a/integration/RKC/actual_integrator_sdc.H
+++ b/integration/RKC/actual_integrator_sdc.H
@@ -15,7 +15,7 @@
 using namespace integrator_rp;
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, Real dt)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -17,7 +17,7 @@
 using namespace integrator_rp;
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();

--- a/integration/VODE/actual_integrator_sdc.H
+++ b/integration/VODE/actual_integrator_sdc.H
@@ -17,7 +17,7 @@
 using namespace integrator_rp;
 
 template <typename BurnT>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 {
     constexpr int int_neqs = integrator_neqs<BurnT>();


### PR DESCRIPTION
This reduces the compilation time for gcc by ~50% and CUDA by ~90%. HIP still takes forever to link, unfortunately.