### PR TITLE
add missing weak rate energy to NSE update

### DIFF
--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -90,6 +90,7 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0, const amrex::Re
     } else {
         rhoe_source = -rho0 * snu;
     }
+    rhoe_source += C::n_A * (C::m_n - (C::m_p + C::m_e)) * C::c_light * C::c_light * rho0 * dyedt0;
 
     amrex::Real rhoaux_source[NumAux];
     rhoaux_source[iye] = rho0 * dyedt0;
@@ -149,6 +150,7 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0, const amrex::Re
     amrex::Real rho_dabar = rho_abar_tilde - rho0 * abar0_out; // this is MeV / nucleon * g / cm**3
 
     drhoedt = rho_dBEA * C::MeV2eV * C::ev2erg * C::n_A / tau;
+    drhoedt += C::n_A * (C::m_n - (C::m_p + C::m_e)) * C::c_light * C::c_light * rho0 * dyedt0;
     if (integrator_rp::nse_include_enu_weak == 1) {
         drhoedt -= rho0 * (nse_state.e_nu + snu);
     } else {


### PR DESCRIPTION
This accounts for the fact that when we just do the binding energy, we don't capture the energy difference from converting protons to neutrons.  That term looks like N_A (m_n - (m_p + m_e) c**2 dY_e/dt.  This adds that to the SDC
update.