### PR TITLE
Disable force-inlining in HIP CI

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           cd unit_test/test_react
           # -amdgpu-function-calls=true tells the compiler not to force-inline everything
-          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 2
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 4
 
       - name: compile test_react with HIP (ignition_reaclib/URCA-simple)
         run: |
           cd unit_test/test_react
           make realclean
-          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 2
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 4

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -32,10 +32,11 @@ jobs:
       - name: compile test_react with HIP (iso7)
         run: |
           cd unit_test/test_react
-          make COMP=gnu USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 -j 2
+          # -amdgpu-function-calls=true tells the compiler not to force-inline everything
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 2
 
       - name: compile test_react with HIP (ignition_reaclib/URCA-simple)
         run: |
           cd unit_test/test_react
           make realclean
-          make COMP=gnu USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple -j 2
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 2


### PR DESCRIPTION
Also remove COMP=gnu, since it's redundant, and bump up the number of parallel make jobs to 4.