### PR TITLE
if we are building with HIP, don't force inlining

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -33,10 +33,10 @@ jobs:
         run: |
           cd unit_test/test_react
           # -amdgpu-function-calls=true tells the compiler not to force-inline everything
-          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 4
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=iso7 -j 4
 
       - name: compile test_react with HIP (ignition_reaclib/URCA-simple)
         run: |
           cd unit_test/test_react
           make realclean
-          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple EXTRACXXFLAGS='-mllvm -amdgpu-function-calls=true' -j 4
+          make USE_HIP=TRUE USE_MPI=FALSE USE_OMP=FALSE USE_CUDA=FALSE NETWORK_DIR=ignition_reaclib/URCA-simple -j 4

--- a/Make.Microphysics_extern
+++ b/Make.Microphysics_extern
@@ -1,6 +1,11 @@
 # This is the main include makefile for applications that want to use Microphysics
 # You should set NETWORK_OUTPUT_PATH before including this file
 
+# For HIP, inlining produces large kernels that seem to cause memory issues
+ifeq ($(USE_HIP),TRUE)
+    EXTRACXXFLAGS += -mllvm -amdgpu-function-calls=true
+endif
+
 # for common code paths between simplified-SDC and true-SDC, we'll
 # use the SDC define
 


### PR DESCRIPTION
this works around some issues with large kernels and ROCm