### PR TITLE
remove redundant (and conflicting) typedefs in rhs.H

### DIFF
--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -272,10 +272,6 @@ constexpr int is_jacobian_term_used ()
 #endif
 }
 
-typedef amrex::Array1D<int, 1, INT_NEQS> IArray1D;
-typedef amrex::Array1D<amrex::Real, 1, INT_NEQS> RArray1D;
-typedef ArrayUtil::MathArray2D<1, INT_NEQS, 1, INT_NEQS> RArray2D;
-
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void dgesl (RArray2D& a1, RArray1D& b1)
 {


### PR DESCRIPTION
in particular, IArray1D was `int` here, but `short` in integrator_data.H