### PR TITLE
standardize names for # of rhs calls, Jac evals, and steps

### DIFF
--- a/integration/RKC/actual_integrator.H
+++ b/integration/RKC/actual_integrator.H
@@ -120,9 +120,9 @@ void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 
     // Get the number of RHS and Jacobian evaluations.
 
-    state.n_rhs = rkc_state.nfe;
+    state.n_rhs = rkc_state.n_rhs;
     state.n_jac = 0;
-    state.n_step = rkc_state.nsteps;
+    state.n_step = rkc_state.n_step;
 
     if (istate != IERR_SUCCESS) {
         state.success = false;
@@ -152,8 +152,8 @@ void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
         std::cout <<  "integration summary: " << std::endl;
         std::cout <<  "dens: " << state.rho << " temp: " << state.T << std::endl;
         std::cout << " energy released: " << state.e << std::endl;
-        std::cout <<  "number of steps taken: " << rkc_state.nsteps << std::endl;
-        std::cout <<  "number of f evaluations: " << rkc_state.nfe << std::endl;
+        std::cout <<  "number of steps taken: " << rkc_state.n_step << std::endl;
+        std::cout <<  "number of f evaluations: " << rkc_state.n_rhs << std::endl;
     }
 #endif
 

--- a/integration/RKC/actual_integrator_sdc.H
+++ b/integration/RKC/actual_integrator_sdc.H
@@ -105,9 +105,9 @@ void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 
     // Get the number of RHS and Jacobian evaluations.
 
-    state.n_rhs = rkc_state.nfe;
+    state.n_rhs = rkc_state.n_rhs;
     state.n_jac = 0;
-    state.n_step = rkc_state.nsteps;
+    state.n_step = rkc_state.n_step;
 
     // Copy the integration data back to the burn state.
     // This will also update the aux state from X if we are using NSE

--- a/integration/RKC/rkc.H
+++ b/integration/RKC/rkc.H
@@ -138,7 +138,7 @@ int rkclow (BurnT& state, RkcT& rstate)
     // we want to call with yn = y as the input and store the output in fn
     rhs(rstate.t, state, rstate, rstate.fn);
 
-    rstate.nfe++;
+    rstate.n_rhs++;
     amrex::Real tdir = std::copysign(1.0_rt, rstate.tout - rstate.t);
     rstate.hmax = std::abs(rstate.tout - rstate.t);
 
@@ -150,7 +150,7 @@ int rkclow (BurnT& state, RkcT& rstate)
     amrex::Real hold{};
 
     // Start of loop for taking one step.
-    while (rstate.nsteps < integrator_rp::ode_max_steps) {
+    while (rstate.n_step < integrator_rp::ode_max_steps) {
 
         // Estimate the spectral radius of the Jacobian
         // when newspc = .true..
@@ -170,7 +170,7 @@ int rkclow (BurnT& state, RkcT& rstate)
 
         // Compute an initial step size.
 
-        if (rstate.nsteps == 0) {
+        if (rstate.n_step == 0) {
             absh = rkc_init_dt(state, rstate, rstate.hmax, sprad);
         }
 
@@ -200,8 +200,8 @@ int rkclow (BurnT& state, RkcT& rstate)
                                            std::abs(rstate.t + h));
         step(state, rstate, h, m);
         rhs(rstate.t+h, state, rstate, rstate.yjm1);
-        rstate.nfe += m;
-        rstate.nsteps++;
+        rstate.n_rhs += m;
+        rstate.n_step++;
 
         // Estimate the local error and compute its weighted RMS norm.
 
@@ -309,8 +309,8 @@ int rkc (BurnT& state, RkcT& rstate)
 
     // Initialize counters and pointers.
 
-    rstate.nfe = 0;
-    rstate.nsteps = 0;
+    rstate.n_rhs = 0;
+    rstate.n_step = 0;
     rstate.naccpt = 0;
     rstate.nrejct = 0;
     rstate.nfesig = 0;

--- a/integration/RKC/rkc_type.H
+++ b/integration/RKC/rkc_type.H
@@ -75,10 +75,10 @@ struct rkc_t {
     // block
 
     // number of function evaluations
-    int nfe;
+    int n_rhs;
 
     // number of integration stesp
-    int nsteps;
+    int n_step;
 
     // number of accepted steps
     int naccpt;

--- a/integration/VODE/actual_integrator.H
+++ b/integration/VODE/actual_integrator.H
@@ -134,9 +134,9 @@ void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 
     // Get the number of RHS and Jacobian evaluations.
 
-    state.n_rhs = vode_state.NFE;
-    state.n_jac = vode_state.NJE;
-    state.n_step = vode_state.NST;
+    state.n_rhs = vode_state.n_rhs;
+    state.n_jac = vode_state.n_jac;
+    state.n_step = vode_state.n_step;
 
     // VODE does not always fail even though it can lead to unphysical states.
     // Add some checks that indicate a burn fail even if VODE thinks the

--- a/integration/VODE/actual_integrator_sdc.H
+++ b/integration/VODE/actual_integrator_sdc.H
@@ -117,9 +117,9 @@ void actual_integrator (BurnT& state, amrex::Real dt, bool is_retry=false)
 
     // Get the number of RHS and Jacobian evaluations.
 
-    state.n_rhs = vode_state.NFE;
-    state.n_jac = vode_state.NJE;
-    state.n_step = vode_state.NST;
+    state.n_rhs = vode_state.n_rhs;
+    state.n_jac = vode_state.n_jac;
+    state.n_step = vode_state.n_step;
 
     // Copy the integration data back to the burn state.
     // This will also update the aux state from X if we are using NSE

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -45,7 +45,7 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
         // steps, we consider the cached Jacobian too old and will want to re-evaluate
         // it, so we look at whether the step of the last Jacobian evaluation (NSLJ)
         // is more than max_steps_between_jacobian_evals steps in the past.
-        if (vstate.NST == 0 || vstate.NST > vstate.NSLJ + max_steps_between_jacobian_evals) {
+        if (vstate.n_step == 0 || vstate.n_step > vstate.NSLJ + max_steps_between_jacobian_evals) {
             evaluate_jacobian = 1;
         }
 
@@ -71,10 +71,10 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
             // For the analytic Jacobian, call the user-supplied function.
 
             // Increment the Jacobian evaluation counter.
-            vstate.NJE += 1;
+            vstate.n_jac += 1;
 
             // Refresh the timestep marker for the last Jacobian evaluation.
-            vstate.NSLJ = vstate.NST;
+            vstate.NSLJ = vstate.n_step;
 
             // Indicate that the Jacobian is current for this solve.
             vstate.JCUR = 1;
@@ -97,10 +97,10 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
             // For the numerical Jacobian, make N calls to the RHS to approximate it.
 
             // Increment the Jacobian evaluation counter.
-            vstate.NJE += 1;
+            vstate.n_jac += 1;
 
             // Refresh the timestep marker for the last Jacobian evaluation.
-            vstate.NSLJ = vstate.NST;
+            vstate.NSLJ = vstate.n_step;
 
             // Indicate that the Jacobian is current for this solve.
             vstate.JCUR = 1;
@@ -133,7 +133,7 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
             }
 
             // Increment the RHS evaluation counter by N.
-            vstate.NFE += int_neqs;
+            vstate.n_rhs += int_neqs;
 
 #ifdef ALLOW_JACOBIAN_CACHING
             // Store the Jacobian if we're caching.

--- a/integration/VODE/vode_dvnlsd.H
+++ b/integration/VODE/vode_dvnlsd.H
@@ -46,7 +46,7 @@ Real dvnlsd (int& NFLAG, BurnT& state, DvodeT& vstate)
     // In any case, DVJAC is called at least every MSBP steps.
 
     vstate.DRC = std::abs(vstate.RC - 1.0_rt);
-    if (vstate.DRC > CCMAX || vstate.NST >= vstate.NSLP + MSBP) {
+    if (vstate.DRC > CCMAX || vstate.n_step >= vstate.NSLP + MSBP) {
         vstate.IPUP = 1;
     }
 
@@ -67,7 +67,7 @@ Real dvnlsd (int& NFLAG, BurnT& state, DvodeT& vstate)
         }
 
         rhs(vstate.tn, state, vstate, vstate.savf);
-        vstate.NFE += 1;
+        vstate.n_rhs += 1;
 
         if (vstate.IPUP == 1) {
 
@@ -82,7 +82,7 @@ Real dvnlsd (int& NFLAG, BurnT& state, DvodeT& vstate)
             vstate.RC = 1.0_rt;
             vstate.DRC = 0.0_rt;
             vstate.CRATE = 1.0_rt;
-            vstate.NSLP = vstate.NST;
+            vstate.NSLP = vstate.n_step;
 
             // If matrix is singular, take error return to force cut in step size.
             if (IERPJ != 0) {
@@ -172,7 +172,7 @@ Real dvnlsd (int& NFLAG, BurnT& state, DvodeT& vstate)
 
             DELP = DEL;
             rhs(vstate.tn, state, vstate, vstate.savf);
-            vstate.NFE += 1;
+            vstate.n_rhs += 1;
 
         }
 

--- a/integration/VODE/vode_dvode.H
+++ b/integration/VODE/vode_dvode.H
@@ -45,8 +45,8 @@ int dvode (BurnT& state, DvodeT& vstate)
 
     vstate.tn = vstate.t;
 
-    vstate.NST = 0;
-    vstate.NJE = 0;
+    vstate.n_step = 0;
+    vstate.n_jac = 0;
     vstate.NSLJ = 0;
 
     // Initial call to the RHS.
@@ -59,7 +59,7 @@ int dvode (BurnT& state, DvodeT& vstate)
         vstate.yh(i,2) = f_init(i);
     }
 
-    vstate.NFE = 1;
+    vstate.n_rhs = 1;
 
     // Load the initial value array in yh.
 
@@ -81,7 +81,7 @@ int dvode (BurnT& state, DvodeT& vstate)
     // Call DVHIN to set initial step size H0 to be attempted.
     H0 = 0.0_rt;
     dvhin(state, vstate, H0, NITER, IER);
-    vstate.NFE += NITER;
+    vstate.n_rhs += NITER;
 
     if (IER != 0) {
 #ifndef AMREX_USE_GPU
@@ -129,7 +129,7 @@ int dvode (BurnT& state, DvodeT& vstate)
            // start of problem), check for too much accuracy being requested, and
            // check for H below the roundoff level in T.
 
-           if (vstate.NST >= ode_max_steps) {
+           if (vstate.n_step >= ode_max_steps) {
                // The maximum number of steps was taken before reaching TOUT.
 #ifndef AMREX_USE_GPU
                std::cout << amrex::Font::Bold << amrex::FGColor::Red << "DVODE: maximum number of steps taken before reaching TOUT" << amrex::ResetDisplay << std::endl;
@@ -164,7 +164,7 @@ int dvode (BurnT& state, DvodeT& vstate)
 
        if (TOLSF > 1.0_rt) {
 
-           if (vstate.NST == 0) {
+           if (vstate.n_step == 0) {
 #ifndef AMREX_USE_GPU
                std::cout << amrex::Font::Bold << amrex::FGColor::Red << "DVODE: too much accuracy requested at start of integration" << amrex::ResetDisplay << std::endl;
 #endif
@@ -229,7 +229,7 @@ int dvode (BurnT& state, DvodeT& vstate)
        // wild exploration.  Also ensure we are not working > tmax,
        // so we don't need to worry about extrapolating back in time.
 
-       if (vstate.NST > MIN_NSE_BAILOUT_STEPS && vstate.tn <= vstate.tout) {
+       if (vstate.n_step > MIN_NSE_BAILOUT_STEPS && vstate.tn <= vstate.tout) {
            // first we need to make the burn_t in sync
 
 #ifdef STRANG

--- a/integration/VODE/vode_dvstep.H
+++ b/integration/VODE/vode_dvstep.H
@@ -319,7 +319,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             // If ETAMAX = 1 (a failure occurred this step), keep NQWAIT >= 2.
 
             kflag = 0;
-            vstate.NST += 1;
+            vstate.n_step += 1;
             for (int iback = 1; iback <= vstate.NQ; ++iback) {
                 const int i = vstate.L - iback;
                 vstate.tau(i+1) = vstate.tau(i);
@@ -352,7 +352,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
             vstate.NEWH = 0;
             vstate.ETA = 1.0_rt;
             vstate.ETAMAX = ETAMX3;
-            if (vstate.NST <= 10) {
+            if (vstate.n_step <= 10) {
                 vstate.ETAMAX = ETAMX2;
             }
 
@@ -455,7 +455,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
         vstate.HSCAL = vstate.H;
         vstate.tau(1) = vstate.H;
         rhs(vstate.tn, state, vstate, vstate.savf);
-        vstate.NFE += 1;
+        vstate.n_rhs += 1;
         for (int i = 1; i <= int_neqs; ++i) {
             vstate.yh(i,2) = vstate.H * vstate.savf(i);
         }
@@ -543,7 +543,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
         vstate.ETA = vstate.ETA / amrex::max(1.0_rt, std::abs(vstate.H) * vstate.HMXI * vstate.ETA);
         vstate.NEWH = 1;
         vstate.ETAMAX = ETAMX3;
-        if (vstate.NST <= 10) {
+        if (vstate.n_step <= 10) {
             vstate.ETAMAX = ETAMX2;
         }
         R = 1.0_rt / vstate.tq(2);
@@ -557,7 +557,7 @@ int dvstep (BurnT& state, DvodeT& vstate)
     vstate.NEWH = 0;
     vstate.ETA = 1.0_rt;
     vstate.ETAMAX = ETAMX3;
-    if (vstate.NST <= 10) {
+    if (vstate.n_step <= 10) {
         vstate.ETAMAX = ETAMX2;
     }
     R = 1.0_rt / vstate.tq(2);

--- a/integration/VODE/vode_type.H
+++ b/integration/VODE/vode_type.H
@@ -75,14 +75,14 @@ struct dvode_t
     // TN     = The independent variable, updated on each step taken
     amrex::Real tn;
 
-    // NFE    = The number of f evaluations for the problem so far
-    int NFE;
+    // n_rhs    = The number of f evaluations for the problem so far
+    int n_rhs;
 
-    // NJE    = The number of Jacobian evaluations so far
-    int NJE;
+    // n_jac    = The number of Jacobian evaluations so far
+    int n_jac;
 
-    // NST    = The number of steps taken for the problem so far
-    int NST;
+    // n_step    = The number of steps taken for the problem so far
+    int n_step;
 
     // ICF    = Integer flag for convergence failure in DVNLSD:
     //            0 means no failures
@@ -119,7 +119,7 @@ struct dvode_t
     // NSLJ   = The number of steps taken as of the last Jacobian update
     int NSLJ;
 
-    // NSLP   = Saved value of NST as of last Newton matrix update
+    // NSLP   = Saved value of n_step as of last Newton matrix update
     int NSLP;
 
     // jacobian_type = the type of Jacobian to use (1 = analytic, 2 = numerical)
@@ -202,9 +202,9 @@ void print_state(dvode_t<int_neqs>& dvode_state)
     std::cout << "tq(4) = " << dvode_state.tq(4) << std::endl;
     std::cout << "tq(5) = " << dvode_state.tq(5) << std::endl;
     std::cout << "tn = " << dvode_state.tn << std::endl;
-    std::cout << "NFE = " << dvode_state.NFE << std::endl;
-    std::cout << "NJE = " << dvode_state.NJE << std::endl;
-    std::cout << "NST = " << dvode_state.NST << std::endl;
+    std::cout << "n_rhs = " << dvode_state.n_rhs << std::endl;
+    std::cout << "n_jac = " << dvode_state.n_jac << std::endl;
+    std::cout << "n_step = " << dvode_state.n_step << std::endl;
     std::cout << "ICF = " << dvode_state.ICF << std::endl;
     std::cout << "IPUP = " << dvode_state.IPUP << std::endl;
     std::cout << "JCUR = " << dvode_state.JCUR << std::endl;

--- a/integration/utils/rkc_util.H
+++ b/integration/utils/rkc_util.H
@@ -42,7 +42,7 @@ amrex::Real rkc_init_dt (BurnT& state, IntT& rstate, const amrex::Real max_times
         rstate.y(i) = ysav(i);
     }
 
-    rstate.n_rhs+;
+    rstate.n_rhs++;
     amrex::Real est{};
 
     // compute the weights using the tolerances

--- a/integration/utils/rkc_util.H
+++ b/integration/utils/rkc_util.H
@@ -42,7 +42,7 @@ amrex::Real rkc_init_dt (BurnT& state, IntT& rstate, const amrex::Real max_times
         rstate.y(i) = ysav(i);
     }
 
-    rstate.nfe++;
+    rstate.n_rhs+;
     amrex::Real est{};
 
     // compute the weights using the tolerances
@@ -106,7 +106,7 @@ int rkcrho (BurnT& state, IntT& rstate, const amrex::Real max_timestep, amrex::R
     // the eigenvector are normalized so that their Euclidean
     // norm has the constant value dynrm.
 
-    if (rstate.nsteps == 0) {
+    if (rstate.n_step == 0) {
         for (int i = 1; i <= INT_NEQS; ++i) {
             rstate.yjm1(i) = rstate.fn(i);
         }


### PR DESCRIPTION
this will make it easier to merge a lot of integrator logic
now VODE, BackwardEuler, and RKC all use the same names