### PR TITLE
clean up some USE_CUDA bits in the makefiles

### DIFF
--- a/integration/VODE/Make.package
+++ b/integration/VODE/Make.package
@@ -5,7 +5,7 @@ else
 endif
 
 # by default we do not enable Jacobian caching on GPUs to save memory
-ifneq ($(USE_CUDA), TRUE)
+ifneq ($(USE_GPU), TRUE)
   DEFINES += -DALLOW_JACOBIAN_CACHING
 endif
 

--- a/unit_test/burn_cell/GNUmakefile
+++ b/unit_test/burn_cell/GNUmakefile
@@ -29,10 +29,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += . ..
 
 Bpack   := ./Make.package

--- a/unit_test/burn_cell_primordial_chem/GNUmakefile
+++ b/unit_test/burn_cell_primordial_chem/GNUmakefile
@@ -32,10 +32,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/eos_cell/GNUmakefile
+++ b/unit_test/eos_cell/GNUmakefile
@@ -29,10 +29,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += . ..
 
 Bpack   := ./Make.package

--- a/unit_test/nse_table_cell/GNUmakefile
+++ b/unit_test/nse_table_cell/GNUmakefile
@@ -30,10 +30,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_ase/GNUmakefile
+++ b/unit_test/test_ase/GNUmakefile
@@ -34,10 +34,6 @@ SCREEN_METHOD := chabrier1998
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_ase/make_table/GNUmakefile
+++ b/unit_test/test_ase/make_table/GNUmakefile
@@ -33,10 +33,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_jac/GNUmakefile
+++ b/unit_test/test_jac/GNUmakefile
@@ -27,10 +27,6 @@ NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_linear_algebra/GNUmakefile
+++ b/unit_test/test_linear_algebra/GNUmakefile
@@ -25,10 +25,6 @@ NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_nse/GNUmakefile
+++ b/unit_test/test_nse/GNUmakefile
@@ -32,10 +32,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += . ..
 
 Bpack   := ./Make.package

--- a/unit_test/test_nse_interp/GNUmakefile
+++ b/unit_test/test_nse_interp/GNUmakefile
@@ -30,10 +30,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_part_func/GNUmakefile
+++ b/unit_test/test_part_func/GNUmakefile
@@ -29,10 +29,6 @@ CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_react/GNUmakefile
+++ b/unit_test/test_react/GNUmakefile
@@ -27,10 +27,6 @@ NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/unit_test/test_rhs/GNUmakefile
+++ b/unit_test/test_rhs/GNUmakefile
@@ -25,10 +25,6 @@ NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package

--- a/util/cj_detonation/GNUmakefile
+++ b/util/cj_detonation/GNUmakefile
@@ -25,10 +25,6 @@ NETWORK_DIR := aprox13
 
 CONDUCTIVITY_DIR := stellar
 
-ifeq ($(USE_CUDA), TRUE)
-  INTEGRATOR_DIR := VODE
-endif
-
 EXTERN_SEARCH += .
 
 Bpack   := ./Make.package ../../unit_test/Make.package


### PR DESCRIPTION
in particular, we don't need to reuire VODE if USE_CUDA=TRUE in unit tests also generalize the disabling of Jacobian caching for any GPU, not just CUDA