### PR TITLE
change how the retry tolerances work

### DIFF
--- a/integration/_parameters
+++ b/integration/_parameters
@@ -67,12 +67,13 @@ use_burn_retry            bool    0
 retry_swap_jacobian       bool    1
 
 # Tolerances for the solver (relative and absolute), for the
-# species and energy equations.
-retry_rtol_spec                real      1.e-12
-retry_rtol_enuc                real      1.e-6
+# species and energy equations.  If set to < 0, then the same
+# value as the first attempt is used.
+retry_rtol_spec                real      -1
+retry_rtol_enuc                real      -1
 
-retry_atol_spec                real      1.e-8
-retry_atol_enuc                real      1.e-6
+retry_atol_spec                real      -1
+retry_atol_enuc                real      -1
 
 # in the clean_state process, do we clip the species such that they
 # are in [0, 1]?

--- a/integration/integrator_setup_sdc.H
+++ b/integration/integrator_setup_sdc.H
@@ -73,15 +73,23 @@ IntegratorT integrator_setup (BurnT& state, amrex::Real dt, bool is_retry)
 
     } else {
 
-        int_state.atol_enuc = sdc_min_density * integrator_rp::retry_atol_enuc;
-        int_state.rtol_enuc = integrator_rp::retry_rtol_enuc;
+        int_state.atol_enuc = integrator_rp::retry_atol_enuc > 0 ?
+            sdc_min_density * integrator_rp::retry_atol_enuc :
+            sdc_min_density * integrator_rp::atol_enuc;
+
+        int_state.rtol_enuc = integrator_rp::retry_rtol_enuc > 0 ?
+            integrator_rp::retry_rtol_enuc : integrator_rp::rtol_enuc;
 
         // Note: we define the input atol for species to refer only to the
         // mass fraction part, and we multiply by a representative density
         // so that atol becomes an absolutely tolerance on (rho X)
 
-        int_state.atol_spec = sdc_min_density * integrator_rp::retry_atol_spec;
-        int_state.rtol_spec = integrator_rp::retry_rtol_spec;
+        int_state.atol_spec = integrator_rp::retry_atol_spec > 0 ?
+            sdc_min_density * integrator_rp::retry_atol_spec :
+            sdc_min_density * integrator_rp::atol_spec;
+
+        int_state.rtol_spec = integrator_rp::retry_rtol_spec > 0 ?
+            integrator_rp::retry_rtol_spec : integrator_rp::rtol_spec;
 
     }
 

--- a/integration/integrator_setup_strang.H
+++ b/integration/integrator_setup_strang.H
@@ -38,11 +38,15 @@ IntegratorT integrator_setup (BurnT& state, amrex::Real dt, bool is_retry)
         int_state.rtol_spec = integrator_rp::rtol_spec; // mass fractions
         int_state.rtol_enuc = integrator_rp::rtol_enuc; // energy generated
     } else {
-        int_state.atol_spec = integrator_rp::retry_atol_spec; // mass fractions
-        int_state.atol_enuc = integrator_rp::retry_atol_enuc; // energy generated
+        int_state.atol_spec = integrator_rp::retry_atol_spec > 0 ?
+            integrator_rp::retry_atol_spec : integrator_rp::atol_spec; // mass fractions
+        int_state.atol_enuc = integrator_rp::retry_atol_enuc > 0 ?
+            integrator_rp::retry_atol_enuc : integrator_rp::atol_enuc; // energy generated
 
-        int_state.rtol_spec = integrator_rp::retry_rtol_spec; // mass fractions
-        int_state.rtol_enuc = integrator_rp::retry_rtol_enuc; // energy generated
+        int_state.rtol_spec = integrator_rp::retry_rtol_spec > 0 ?
+            integrator_rp::retry_rtol_spec : integrator_rp::rtol_spec; // mass fractions
+        int_state.rtol_enuc = integrator_rp::retry_rtol_enuc > 0 ?
+            integrator_rp::retry_rtol_enuc : integrator_rp::rtol_enuc; // energy generated
     }
 
     // set the Jacobian type

--- a/sphinx_docs/source/ode_integrators.rst
+++ b/sphinx_docs/source/ode_integrators.rst
@@ -219,6 +219,13 @@ The runtime parameters that come into play when doing the retry are:
 
 * ``retry_atol_enuc`` : absolute tolerance for the energy on retry
 
+.. note::
+
+   If you set any of the retry tolerances to be less than $0$, then
+   the original (non-retry) tolerance is used on retry.  The default
+   value for all of the retry tolerances is $-1$, which means the same
+   tolerances are used on retry unless you override them at runtime.
+
 .. tip::
 
    Sometimes a simulation runs best if you set


### PR DESCRIPTION
they now default to -1, in which case the original (non-retry) tolerance will be used.  This makes it easier for a user to use the retry mechanism without having to remember to explicitly set all of the tolerances