### PR TITLE
Fix FPE in templated networks

### DIFF
--- a/screening/screen.H
+++ b/screening/screen.H
@@ -645,12 +645,12 @@ void actual_screen(const plasma_state_t<dual_t>& state,
 {
     dual_t scor_dual;
     scor_dual = actual_screen(state, scn_fac);
-    if constexpr (std::is_same_v<dual_t, amrex::Real>) {
-        scor = scor_dual;
-        scordt = std::numeric_limits<amrex::Real>::signaling_NaN();
-    } else {
+    if constexpr (autodiff::detail::isDual<dual_t>) {
         scor = autodiff::val(scor_dual);
         scordt = autodiff::derivative(scor_dual);
+    } else {
+        scor = scor_dual;
+        scordt = std::numeric_limits<amrex::Real>::quiet_NaN();
     }
 }
 

--- a/sphinx_docs/source/autodiff.rst
+++ b/sphinx_docs/source/autodiff.rst
@@ -21,6 +21,9 @@ replaced with ones in the ``admath`` namespace.  This namespace also
 exports the original functions, so they work fine on normal numeric
 types too.
 
+To manually check whether a type is a dual number or not, use
+``autodiff::detail::isDual<dual_t>``.
+
 Derivatives of single-variable functions
 ========================================
 


### PR DESCRIPTION
Also document `autodiff::detail::isDual` for checking templated types.

I'm leaving this as a quiet NaN so it will show up in outputs if it ever gets used by accident, but won't immediately trigger a floating-point exception.