### PR TITLE
Avoid dividing by zero in constexpr linear algebra routines

### DIFF
--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -169,8 +169,7 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
     int IER{};
 
 #ifdef NEW_NETWORK_IMPLEMENTATION
-    RHS::dgefa(vstate.jac);
-    IER = 0;
+    RHS::dgefa(vstate.jac, IER);
 #else
     if (integrator_rp::linalg_do_pivoting == 1) {
         constexpr bool allow_pivot{true};

--- a/integration/VODE/vode_dvjac.H
+++ b/integration/VODE/vode_dvjac.H
@@ -169,7 +169,7 @@ void dvjac (int& IERPJ, BurnT& state, DvodeT& vstate)
     int IER{};
 
 #ifdef NEW_NETWORK_IMPLEMENTATION
-    RHS::dgefa(vstate.jac, IER);
+    IER = RHS::dgefa(vstate.jac);
 #else
     if (integrator_rp::linalg_do_pivoting == 1) {
         constexpr bool allow_pivot{true};

--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -307,7 +307,7 @@ void dgesl (const RArray2D& a, RArray1D& b)
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void dgefa (RArray2D& a)
+void dgefa (RArray2D& a, int& info)
 {
 
     // LU factorization in-place without pivoting.
@@ -317,6 +317,10 @@ void dgefa (RArray2D& a)
         [[maybe_unused]] constexpr int k = n1;
 
         // compute multipliers
+        if (a(k, k) == 0.0_rt) {
+            info = k;
+            return; // same as continue in a normal loop
+        }
 
         amrex::Real t = -1.0_rt / a(k,k);
         amrex::constexpr_for<k+1, INT_NEQS+1>([&] (auto n2)

--- a/networks/rhs.H
+++ b/networks/rhs.H
@@ -307,10 +307,12 @@ void dgesl (const RArray2D& a, RArray1D& b)
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void dgefa (RArray2D& a, int& info)
+int dgefa (RArray2D& a)
 {
 
     // LU factorization in-place without pivoting.
+
+    int info = 0;
 
     amrex::constexpr_for<1, INT_NEQS>([&] (auto n1)
     {
@@ -344,6 +346,8 @@ void dgefa (RArray2D& a, int& info)
             });
         });
     });
+
+    return info;
 }
 
 // Calculate the density dependence term for tabulated rates. The RHS has a term

--- a/unit_test/test_linear_algebra/test_linear_algebra.H
+++ b/unit_test/test_linear_algebra/test_linear_algebra.H
@@ -101,9 +101,7 @@ void linear_algebra() {
 
     // solve the linear system with the templated solver
 
-    int info;
-
-    RHS::dgefa(A, info);
+    RHS::dgefa(A);
     RHS::dgesl(A, b);
 
     std::cout << std::setprecision(16);
@@ -124,6 +122,7 @@ void linear_algebra() {
     b = Ax(A, x);
 
     IArray1D pivot;
+    int info;
 
     constexpr bool allow_pivot{true};
 

--- a/unit_test/test_linear_algebra/test_linear_algebra.H
+++ b/unit_test/test_linear_algebra/test_linear_algebra.H
@@ -101,7 +101,9 @@ void linear_algebra() {
 
     // solve the linear system with the templated solver
 
-    RHS::dgefa(A);
+    int info;
+
+    RHS::dgefa(A, info);
     RHS::dgesl(A, b);
 
     std::cout << std::setprecision(16);
@@ -122,7 +124,6 @@ void linear_algebra() {
     b = Ax(A, x);
 
     IArray1D pivot;
-    int info;
 
     constexpr bool allow_pivot{true};
 


### PR DESCRIPTION
`RHS::dgefa()` now stops if the matrix is singular, and returns an integer that works the same as the `info` parameter for the routine in `linpack.H`. If the LU decomposition fails, it is the index of the row that failed, and is zero if the decomposition succeeded.

This fixes the crash in `Detonation-collision-retry-SDC` in the Castro test suite. The benchmark does need to be updated, since it now stops at step 10 instead of 11, and the plotfile for that step was last updated before we changed the setup in https://github.com/AMReX-Astro/Castro/pull/2806.