### PR TITLE
Update `autodiff::dual` to give the same results as `amrex::Real`

### DIFF
--- a/unit_test/burn_cell/ci-benchmarks/chamulak_VODE_unit_test.out
+++ b/unit_test/burn_cell/ci-benchmarks/chamulak_VODE_unit_test.out
@@ -1,5 +1,5 @@
-Initializing AMReX (24.06-22-g731014ff3eed)...
-AMReX (24.06-22-g731014ff3eed) initialized
+Initializing AMReX (24.07-16-gdcb9cc0383dc)...
+AMReX (24.07-16-gdcb9cc0383dc) initialized
 starting the single zone burn...
 Maximum Time (s): 0.01585
 State Density (g/cm^3): 1000000000
@@ -13,21 +13,21 @@ RHS at t = 0
    ash 0.01230280576
 ------------------------------------
 successful? 1
- - Hnuc = 5.277400893e+17
- - added e = 8.364680415e+15
- - final T = 1433712612
+ - Hnuc = 5.277406331e+17
+ - added e = 8.364689034e+15
+ - final T = 1433713030
 ------------------------------------
 e initial = 1.253426044e+18
-e final =   1.261790725e+18
+e final =   1.261790733e+18
 ------------------------------------
 new mass fractions: 
-C12 0.9657895158
+C12 0.9657894806
 O16 1e-30
-ash 0.03421048417
+ash 0.03421051942
 ------------------------------------
 species creation rates: 
-omegadot(C12): -2.158390168
-omegadot(O16): 9.946124747e-44
-omegadot(ash): 2.158390168
+omegadot(C12): -2.158392392
+omegadot(O16): 8.840999775e-44
+omegadot(ash): 2.158392392
 number of steps taken: 381
-AMReX (24.06-22-g731014ff3eed) finalized
+AMReX (24.07-16-gdcb9cc0383dc) finalized

--- a/util/microphysics_autodiff.H
+++ b/util/microphysics_autodiff.H
@@ -12,6 +12,9 @@
 
 // required for AMREX_GPU_HOST_DEVICE, which is used via AUTODIFF_DEVICE_FUNC
 #include <AMReX_GpuQualifiers.H>
+// disable some optimizations that break standard left-to-right operator
+// associativity, giving slightly different results with Dual vs. double
+#define AUTODIFF_STRICT_ASSOCIATIVITY
 #include <autodiff/forward/dual.hpp>
 #include <autodiff/forward/utils/derivative.hpp>
 


### PR DESCRIPTION
In my testing with converting the `aprox*` rates to use autodiff, I found a lot of instances where code templated with `autodiff::dual` would give slightly different values than the same code templated with `amrex::Real`. It turns out to be due to some optimizations autodiff makes to speed up evaluation, which this PR disables to avoid any weird inconsistencies in the future.