### PR TITLE
lower ode_max_steps and make burn retry on by default

### DIFF
--- a/integration/_parameters
+++ b/integration/_parameters
@@ -44,7 +44,7 @@ MAX_TEMP                     real            1.0e11
 react_boost                 real         -1.e0
 
 # maximum number of timesteps for the integrator
-ode_max_steps              int      150000
+ode_max_steps              int      25000
 
 # maximum timestep for the integrator
 ode_max_dt                 real         1.e30
@@ -60,7 +60,7 @@ nonaka_level            int           0
 nonaka_file             string       "nonaka_plot.dat"
 
 # do we retry a failed burn with different parameters?
-use_burn_retry            bool    0
+use_burn_retry            bool    1
 
 # do we swap the Jacobian (from analytic to numerical or vice versa) on
 # a retry?


### PR DESCRIPTION
experience with science problems has shown that, especially on GPUs, one zone can take ode_max_steps and then fail, forcing the application code to deal with it (e.g. Castro retries).  But often using the burn retry functionality (in particular swapping the Jacobian) makes the zone pass.

This change lowers ode_max_steps from 150000 to 25000 and turns on the retry (which only enables Jacobian swapping by default). This should help with a lot of applications, although lowering ode_max_steps more can help further.