### PR TITLE
display state.xn in scientific notation

### DIFF
--- a/integration/integrator_setup_strang.H
+++ b/integration/integrator_setup_strang.H
@@ -210,7 +210,7 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
             std::cout << "temp start = " << std::setprecision(16) << state_save.T_in << std::endl;
             std::cout << "xn start = ";
             for (const double X : state_save.xn_in) {
-                std::cout << std::setprecision(16) << X << " ";
+                std::cout << std::scientific << std::setprecision(16) << X << " ";
             }
             std::cout << std::endl;
             std::cout << "dens current = " << std::setprecision(16) << state.rho << std::endl;

--- a/integration/integrator_setup_strang.H
+++ b/integration/integrator_setup_strang.H
@@ -217,7 +217,7 @@ void integrator_cleanup (IntegratorT& int_state, BurnT& state,
             std::cout << "temp current = " << std::setprecision(16) << state.T << std::endl;
             std::cout << "xn current = ";
             for (const double X : state.xn) {
-                std::cout << std::setprecision(16) << X << " ";
+                std::cout << std::scientific << std::setprecision(16) << X << " ";
             }
             std::cout << std::endl;
             std::cout << "energy generated = " << state.e << std::endl;


### PR DESCRIPTION
If state.xn contains number densities (e.g., for primordial and metal chemistry), it can be hard to read large values when they are not printed in scientific format. This is not an issue for other cases where mass fractions are being used, since they are always <=1 .