### PR TITLE
Remove hardcoded charge balance in primordial chemistry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
     set(primordial_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
                                 ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
                                 ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS/primordial_chem/actual_eos_data.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/primordial_chem/actual_network_data.cpp
                                 ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
 
 

--- a/networks/primordial_chem/actual_network.H
+++ b/networks/primordial_chem/actual_network.H
@@ -6,6 +6,7 @@
 
 #include <fundamental_constants.H>
 #include <network_properties.H>
+#include <burn_type.H>
 
 using namespace amrex;
 

--- a/networks/primordial_chem/actual_network.H
+++ b/networks/primordial_chem/actual_network.H
@@ -26,4 +26,6 @@ namespace Rates
 
 }
 
+void balance_charge(burn_t& state);
+
 #endif

--- a/networks/primordial_chem/actual_network_data.cpp
+++ b/networks/primordial_chem/actual_network_data.cpp
@@ -10,3 +10,12 @@ void actual_network_init()
 {
 
 }
+
+void balance_charge(burn_t& state)
+{
+
+    // update the number density of electrons due to charge conservation
+    state.xn[0] = -state.xn[3] - state.xn[7] + state.xn[1] + state.xn[12] +
+                  state.xn[6] + state.xn[4] + state.xn[9] + 2.0 * state.xn[11];
+
+}

--- a/unit_test/burn_cell_primordial_chem/burn_cell.H
+++ b/unit_test/burn_cell_primordial_chem/burn_cell.H
@@ -8,6 +8,7 @@
 #include <eos.H>
 #include <extern_parameters.H>
 #include <network.H>
+#include <actual_network.H>
 
 amrex::Real grav_constant = 6.674e-8;
 
@@ -209,8 +210,7 @@ auto burn_cell_c() -> int {
     }
 
     // update the number density of electrons due to charge conservation
-    state.xn[0] = -state.xn[3] - state.xn[7] + state.xn[1] + state.xn[12] +
-                  state.xn[6] + state.xn[4] + state.xn[9] + 2.0 * state.xn[11];
+    balance_charge(state);
 
     // reconserve mass fractions post charge conservation
     insum = 0;


### PR DESCRIPTION
We now use a function that does the charge balance for primordial chemistry, similar to that done for metal chemistry in #1642 