### PR TITLE
Remove unused param

### DIFF
--- a/networks/metal_chem/_parameters
+++ b/networks/metal_chem/_parameters
@@ -9,8 +9,6 @@ redshift                          real               0e0
 metallicity                          real               1e0
 # dust to gas ratio relative to solar
 dust2gas_ratio                 real               1e0
-# starting index for gas-phase species (after the ices)
-idx_gas_species                int                2
 
 # Cosmic ray ionization rate (per s)
 crate                          real               0e0


### PR DESCRIPTION
Turns out that we don't actually need a parameter to differentiate between ice and gas species indices in quokka.