### PR TITLE
Define Tdust as an auxiliary variable in primordial chemistry

### DIFF
--- a/networks/primordial_chem/pynucastro.net
+++ b/networks/primordial_chem/pynucastro.net
@@ -12,3 +12,4 @@ hd                 HD       17.0    8.0
 hepp               HEpp     17.0    9.0
 hep                HEp      18.0    9.0
 he                 HE       4.0     2.0
+__aux_Tdust


### PR DESCRIPTION
Even though there is no dust in primordial chemistry, we define Tdust as an auxiliary variable so that we don't need to differentiate between primordial and metal chemistry in quokka. For additional context, see line https://github.com/psharda/quokka/blob/metal_chem/src/chemistry/Chemistry.hpp#L99, which will be added to quokka via https://github.com/quokka-astro/quokka/pull/723