### PR TITLE
add a init_species_all_equal option to burn_cell

### DIFF
--- a/unit_test/burn_cell/GNUmakefile
+++ b/unit_test/burn_cell/GNUmakefile
@@ -24,7 +24,7 @@ EOS_DIR     := helmholtz
 
 # This sets the network directory
 NETWORK_DIR := aprox13
-
+SCREEN_METHOD := screen5
 CONDUCTIVITY_DIR := stellar
 
 INTEGRATOR_DIR =  VODE

--- a/unit_test/burn_cell/_parameters
+++ b/unit_test/burn_cell/_parameters
@@ -19,3 +19,5 @@ density       real       1.e7
 temperature   real       3.e9
 
 skip_initial_normalization    bool    0
+
+init_species_all_equal        bool    0

--- a/unit_test/burn_cell/burn_cell.H
+++ b/unit_test/burn_cell/burn_cell.H
@@ -22,7 +22,7 @@ void burn_cell_c()
     for (int n = 1; n <= NumSpec; ++n) {
 
         if (unit_test_rp::init_species_all_equal) {
-            massfractions[n-1] = 1.0_rt / static_cast<Real>(NumSpec);
+            massfractions[n-1] = 1.0_rt / static_cast<amrex::Real>(NumSpec);
         } else {
             massfractions[n-1] = get_xn(n);
 

--- a/unit_test/burn_cell/burn_cell.H
+++ b/unit_test/burn_cell/burn_cell.H
@@ -21,12 +21,15 @@ void burn_cell_c()
     // Make sure user set all the mass fractions to values in the interval [0, 1]
     for (int n = 1; n <= NumSpec; ++n) {
 
-        massfractions[n-1] = get_xn(n);
+        if (unit_test_rp::init_species_all_equal) {
+            massfractions[n-1] = 1.0_rt / static_cast<Real>(NumSpec);
+        } else {
+            massfractions[n-1] = get_xn(n);
 
-        if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
-            amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
+            if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
+                amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
+            }
         }
-
     }
 
     // Echo initial conditions at burn and fill burn state input


### PR DESCRIPTION
if this is True, then we don't need to specify the mass fractions individually, instead they are all initialized to X = 1/NumSpec