### PR TITLE
remove duplicate init_species_all_equal in favor of uniform_xn

### DIFF
--- a/Docs/source/burn_cell.rst
+++ b/Docs/source/burn_cell.rst
@@ -80,7 +80,7 @@ by setting:
 
 ::
 
-    unit_test.init_species_all_equal = 1
+    unit_test.uniform_xn = 1
 
 
 Controlling time

--- a/unit_test/_parameters
+++ b/unit_test/_parameters
@@ -39,3 +39,6 @@ X32           real       0.0e0
 X33           real       0.0e0
 X34           real       0.0e0
 X35           real       0.0e0
+
+uniform_xn    bool        0
+

--- a/unit_test/burn_cell/_parameters
+++ b/unit_test/burn_cell/_parameters
@@ -17,5 +17,3 @@ density       real       1.e7
 temperature   real       3.e9
 
 skip_initial_normalization    bool    0
-
-init_species_all_equal        bool    0

--- a/unit_test/burn_cell/burn_cell.H
+++ b/unit_test/burn_cell/burn_cell.H
@@ -21,14 +21,10 @@ void burn_cell_c()
     // Make sure user set all the mass fractions to values in the interval [0, 1]
     for (int n = 1; n <= NumSpec; ++n) {
 
-        if (unit_test_rp::init_species_all_equal) {
-            massfractions[n-1] = 1.0_rt / static_cast<amrex::Real>(NumSpec);
-        } else {
-            massfractions[n-1] = get_xn(n);
+        massfractions[n-1] = get_xn(n, unit_test_rp::uniform_xn);
 
-            if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
-                amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
-            }
+        if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
+            amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
         }
     }
 

--- a/unit_test/burn_cell_sdc/burn_cell.H
+++ b/unit_test/burn_cell_sdc/burn_cell.H
@@ -20,7 +20,7 @@ void burn_cell_c()
     // Make sure user set all the mass fractions to values in the interval [0, 1]
     for (int n = 1; n <= NumSpec; ++n) {
 
-        massfractions[n-1] = get_xn(n);
+        massfractions[n-1] = get_xn(n, unit_test_rp::uniform_xn);
 
         if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
             amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");

--- a/unit_test/eos_cell/eos_cell.H
+++ b/unit_test/eos_cell/eos_cell.H
@@ -24,7 +24,7 @@ void eos_cell_c()
     // Make sure user set all the mass fractions to values in the interval [0, 1]
     for (int n = 1; n <= NumSpec; ++n) {
 
-        massfractions[n-1] = get_xn(n);
+        massfractions[n-1] = get_xn(n, unit_test_rp::uniform_xn);
 
         if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
             amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");

--- a/unit_test/jac_cell/jac_cell.H
+++ b/unit_test/jac_cell/jac_cell.H
@@ -22,7 +22,7 @@ void jac_cell_c()
     // Make sure user set all the mass fractions to values in the interval [0, 1]
     for (int n = 1; n <= NumSpec; ++n) {
 
-        massfractions[n-1] = get_xn(n);
+        massfractions[n-1] = get_xn(n, unit_test_rp::uniform_xn);
 
         if (massfractions[n-1] < 0 || massfractions[n-1] > 1) {
             amrex::Error("mass fraction for " + short_spec_names_cxx[n-1] + " not initialized in the interval [0,1]!");
@@ -38,7 +38,9 @@ void jac_cell_c()
         burn_state.xn[n] = massfractions[n];
     }
 
-    normalize_abundances_burn(burn_state);
+    if (! unit_test_rp::skip_initial_normalization) {
+        normalize_abundances_burn(burn_state);
+    }
 
     // get the energy
 

--- a/unit_test/react_util.H
+++ b/unit_test/react_util.H
@@ -88,7 +88,7 @@ init_t setup_composition(const int nz) {
 
 
 AMREX_INLINE AMREX_GPU_HOST_DEVICE
-void get_xn(const int k, const init_t cd, amrex::Real *xn_zone, int uniform_composition = 0) {
+void get_xn(const int k, const init_t cd, amrex::Real *xn_zone, bool uniform_composition=false) {
 
     for (int n = 0; n < NumSpec; n++) {
         xn_zone[n] = 0.0_rt;
@@ -167,9 +167,14 @@ void get_xn(const int k, const init_t cd, amrex::Real *xn_zone, int uniform_comp
 ///
 
 AMREX_INLINE AMREX_GPU_HOST_DEVICE
-amrex::Real get_xn(const int index) {
+amrex::Real get_xn(const int index, bool uniform_composition=false) {
 
     amrex::Real mass_fraction{};
+
+    if (uniform_composition) {
+        mass_fraction = 1.0_rt / NumSpec;
+        return mass_fraction;
+    }
 
     switch (index) {
 

--- a/unit_test/test_react/_parameters
+++ b/unit_test/test_react/_parameters
@@ -5,8 +5,6 @@ dens_max      real       1.e9
 temp_min      real       1.e6
 temp_max      real       1.e15
 
-uniform_xn    int        0
-
 tmax          real       0.1e0
 
 small_temp    real       1.e5


### PR DESCRIPTION
test_react had already implemented uniform_xn, so now we bump that runtime parameter up a level so all unit tests can use it.

This also updates `eos_cell`, `burn_cell_sdc`, and `jac_cell` to support this feature.