### PR TITLE
update constant module to use scipy value and remove using legacy constants

### DIFF
--- a/constants/write_fundamental_constants.py
+++ b/constants/write_fundamental_constants.py
@@ -1,4 +1,26 @@
+#!/usr/bin/env python3
 
+import os
+import warnings
+import math
+from scipy import constants
+
+'''
+This scripts writes out fundamental_constants.H
+where most constants are from scipy.constants
+'''
+
+# Find PATH to write the file
+MICROPHYSICS_HOME = os.environ.get("MICROPHYSICS_HOME")
+if MICROPHYSICS_HOME is None:
+    warnings.warn("MICROPHYSICS_HOME is not set. Writing to current directory.", stacklevel=2)
+    fname = "fundamental_constants.H"
+else:
+    fname = os.path.join(MICROPHYSICS_HOME, "constants/fundamental_constants.H")
+
+
+text = \
+f"""
 #ifndef FUNDAMENTAL_CONSTANTS_H
 #define FUNDAMENTAL_CONSTANTS_H
 
@@ -14,9 +36,9 @@
 //
 
 namespace C
-{
+{{
     // speed of light in vacuum
-    constexpr amrex::Real c_light = 29979245800.0;  // cm/s
+    constexpr amrex::Real c_light = {constants.value("speed of light in vacuum") / constants.centi};  // cm/s
 
     // newton's gravitational constant
     constexpr amrex::Real Gconst = 6.67428e-8;  // cm^3/g/s^2
@@ -25,25 +47,25 @@ namespace C
     // constexpr amrex::Real Gconst = 6.67384e-8;  // cm^3/g/s^2
 
     // boltzmann's constant
-    constexpr amrex::Real k_B = 1.3806490000000002e-16;  // erg/K
+    constexpr amrex::Real k_B = {constants.value("Boltzmann constant") / constants.erg};  // erg/K
 
     // planck's constant over 2pi
-    constexpr amrex::Real hbar = 1.0545718176461563e-27;  // erg
+    constexpr amrex::Real hbar = {constants.value("Planck constant") / (2.0 * math.pi * constants.erg)};  // erg
 
     // planck's constant
-    constexpr amrex::Real hplanck = 6.62607015e-27;  // erg s
+    constexpr amrex::Real hplanck = {constants.value("Planck constant") / constants.erg};  // erg s
 
     // avogradro's Number
-    constexpr amrex::Real n_A = 6.02214076e+23;  // mol^-1
+    constexpr amrex::Real n_A = {constants.value("Avogadro constant")};  // mol^-1
 
     // convert eV to erg
-    constexpr amrex::Real ev2erg = 1.602176634e-12;
+    constexpr amrex::Real ev2erg = {constants.eV / constants.erg};
 
     // convert MeV to eV
     constexpr amrex::Real MeV2eV = 1.0e6;
 
     // convert MeV to erg
-    constexpr amrex::Real MeV2erg = 1.6021766339999998e-06;
+    constexpr amrex::Real MeV2erg = {constants.mega * constants.eV / constants.erg};
 
     // convert MeV to grams
     constexpr amrex::Real MeV2gr  = (MeV2eV * ev2erg) / (c_light * c_light);
@@ -52,16 +74,16 @@ namespace C
     constexpr amrex::Real enuc_conv2 = -n_A * c_light * c_light;
 
     // mass of proton
-    constexpr amrex::Real m_p = 1.67262192595e-24;  // g
+    constexpr amrex::Real m_p = {constants.value("proton mass") * constants.kilo};  // g
 
     // mass of neutron
-    constexpr amrex::Real m_n = 1.6749275005600003e-24;  // g
+    constexpr amrex::Real m_n = {constants.value("neutron mass") * constants.kilo};  // g
 
     // mass of electron
-    constexpr amrex::Real m_e = 9.1093837139e-28;  // g
+    constexpr amrex::Real m_e = {constants.value("electron mass") * constants.kilo};  // g
 
     // atomic mass unit
-    constexpr amrex::Real m_u = 1.66053906892e-24; // g
+    constexpr amrex::Real m_u = {constants.value("unified atomic mass unit") * constants.kilo}; // g
 
     // electron charge
     // NIST: q_e = 1.602176565e-19 C
@@ -70,10 +92,10 @@ namespace C
     //     1 C = 0.1 * |c_light| * 1 statC
     // where statC is the cgs unit statCoulomb; 1 statC = 1 erg^1/2 cm^1/2
     // and |c_light| is the speed of light in cgs (but without units)
-    constexpr amrex::Real q_e = 4.803204712570263e-10;  // erg^1/2 cm^1/2
+    constexpr amrex::Real q_e = {constants.value("elementary charge") * (constants.c * 100) / 10};  // erg^1/2 cm^1/2
 
     // stefan-boltzmann constant
-    constexpr amrex::Real sigma_SB = 5.670374419184432e-05;  // erg/s/cm^2/K^4
+    constexpr amrex::Real sigma_SB = {constants.value("Stefan-Boltzmann constant") * constants.centi**2 / constants.erg};  // erg/s/cm^2/K^4
 
     // radiation constant
     constexpr amrex::Real a_rad = 4.0*sigma_SB/c_light;
@@ -82,10 +104,10 @@ namespace C
     // Note that since the length of an AU is defined exactly
     // by IAU convention, the length of a parsec is also
     // defined exactly as (6.48e5 / pi) AU.
-    constexpr amrex::Real AU = 14959787070000.0;  // cm
-    constexpr amrex::Real parsec = 3.085677581491367e+18;  // cm
+    constexpr amrex::Real AU = {constants.au / constants.centi};  // cm
+    constexpr amrex::Real parsec = {constants.parsec / constants.centi};  // cm
 
-    // Hubble constant (in s^{-1}, converted from 100 (km/s)/Mpc by dividing by 3.08568025e19km/Mpc)
+    // Hubble constant (in s^{{-1}}, converted from 100 (km/s)/Mpc by dividing by 3.08568025e19km/Mpc)
     constexpr amrex::Real Hubble_const = 32.407764868e-19;
 
     // solar mass (from http://asa.usno.navy.mil/SecK/Constants.html)
@@ -95,7 +117,7 @@ namespace C
     constexpr amrex::Real R_solar = 6.957e10;
 
     namespace Legacy
-    {
+    {{
         // These are the values of the constants used in the original aprox networks
         constexpr amrex::Real m_n = 1.67492721184e-24;
         constexpr amrex::Real m_p = 1.67262163783e-24;
@@ -109,7 +131,12 @@ namespace C
 
         // conversion factor for nuclear energy generation rate
         constexpr amrex::Real enuc_conv2 = -n_A * c_light * c_light;
-    }
-}
+    }}
+}}
 
 #endif
+"""
+
+
+with open(fname, "w") as f:
+    f.write(text)

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -408,7 +408,7 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
     for (int n = 1; n <= NumSpec; ++n) {
         rhoe_source += rho0 * ydot_weak(n) * network::mion(n);
     }
-    rhoe_source *= C::Legacy::enuc_conv2;
+    rhoe_source *= C::enuc_conv2;
 
     // include plasma neutrino terms
 
@@ -466,7 +466,7 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
         drhoedt += (nse_state1.y[SFS+n] - tau * ydot_a[SFS+n] -
                     nse_state0.y[SFS+n]) * aion_inv[n] * network::mion(n+1);
     }
-    drhoedt *= C::Legacy::enuc_conv2 / tau;
+    drhoedt *= C::enuc_conv2 / tau;
 
     // include neutrino terms again
 

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -51,7 +51,7 @@ T get_nonexponent_nse_state(const T& state) {
     // the temperature that comes in through T_fixed
 
     amrex::Real T_in = state.T_fixed > 0.0_rt ? state.T_fixed : state.T;
-    constexpr amrex::Real ihplanck2 = 1.0_rt / (C::hplanck * C::hplanck);
+    constexpr amrex::Real i2PiHbar2 = 1.0_rt / (2.0_rt * M_PI * C::hbar * C::hbar);
 
 #ifndef NEW_NETWORK_IMPLEMENTATION
     auto tfactors = evaluate_tfactors(T_in);
@@ -74,8 +74,7 @@ T get_nonexponent_nse_state(const T& state) {
 
         // find nse mass frac without the exponent term.
 
-        amrex::Real power = 2.0_rt * M_PI * network::mion(n+1) *
-            C::k_B * T_in * ihplanck2;
+        amrex::Real power = network::mion(n+1) * C::k_B * T_in * i2PiHbar2;
 
         nse_state.xn[n] = network::mion(n+1) * pf * spin / state.rho *
             std::sqrt(amrex::Math::powi<3>(power));
@@ -104,7 +103,7 @@ void compute_coulomb_contribution(amrex::Array1D<amrex::Real, 1, NumSpec>& u_c,
     // so we just treat u_c as a constant.
     //
 
-    const amrex::Real n_e = state.rho * state.y_e * C::Legacy::n_A;
+    const amrex::Real n_e = state.rho * state.y_e * C::n_A;
     const amrex::Real Gamma_e = C::q_e * C::q_e *
         std::cbrt(1.333333333333_rt * M_PI * n_e) / (C::k_B * T_in);
     amrex::Real gamma;
@@ -128,7 +127,7 @@ void compute_coulomb_contribution(amrex::Array1D<amrex::Real, 1, NumSpec>& u_c,
         //
         // Here u_c is a dimensionless quantity.
         // Otherwise:
-        // u_c = C::k_B * T_in / C::Legacy::MeV2erg * f;
+        // u_c = C::k_B * T_in / C::MeV2erg * f;
         //
 
         u_c(n+1) = f;
@@ -147,7 +146,7 @@ void apply_nse_exponent(T& nse_state,
     // the temperature that comes in through T_fixed
 
     amrex::Real T_in = nse_state.T_fixed > 0.0_rt ? nse_state.T_fixed : nse_state.T;
-    amrex::Real ikTMeV = C::Legacy::MeV2erg / (C::k_B * T_in);
+    amrex::Real ikTMeV = C::MeV2erg / (C::k_B * T_in);
     amrex::Real exponent;
 
     for (int n = 0; n < NumSpec; ++n) {
@@ -250,7 +249,7 @@ void jcn(amrex::Array1D<amrex::Real, 1, 2>& x, amrex::Array2D<amrex::Real, 1, 2,
     // the temperature that comes in through T_fixed
 
     amrex::Real T_in = nse_state.T_fixed > 0.0_rt ? nse_state.T_fixed : nse_state.T;
-    amrex::Real ikTMeV = C::Legacy::MeV2erg / (C::k_B * T_in);
+    amrex::Real ikTMeV = C::MeV2erg / (C::k_B * T_in);
 
     for (int n = 0; n < NumSpec; ++n) {
 #ifdef NEW_NETWORK_IMPLEMENTATION


### PR DESCRIPTION
added a script to auto generate scipy constant value. Address issue #1655.