### PR TITLE
update nse_sdc_burn for NSE_NET

### DIFF
--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -93,10 +93,10 @@ Here we give outline on how the reactive update is done with NSE.
     * Now evolve $\rho$, $\rho e$, and $\rho Y_e$ to midpoint in time:
 
       .. math::
-         \Uc^{\prime,n+1/2} = \Uc^{\prime,n} + \frac{\Delta t}{2} \left([\Advs{\Uc^\prime}]^{n} + [\Rb(\Uc^\prime)]^{n}\right)
+         \Uc^{\prime,n+1/2} = \Uc^{\prime,n} + \frac{\Delta t}{2} \left([\Advs{\Uc^\prime}]^{n+1/2} + [\Rb(\Uc^\prime)]^{n}\right)
 
       Note that there is no reactive source term for $\rho$ and the advective
-      source term is constant throughout the reactive update.
+      source term is already time-centered from the simplified-SDC algorithm.
 
     * Compute $[\Rb(\rho Y_e)]^{n+1/2}$ and
       $[\Rb(\rho e)_{\mathrm{nuc}}]^{n+1/2}$ following the same

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -65,7 +65,7 @@ Here we give outline on how the reactive update is done with NSE.
       * Compute the thermal neutrino losses,
         $\epsilon_{\nu,\mathrm{thermal}}$, using the NSE composition.
 
-      * Evaluate $\dot{Y}_{\mathrm{weak}} and neutrino losses,
+      * Evaluate $\dot{Y}_{\mathrm{weak}}$ and neutrino losses,
         $\epsilon_{\nu,\mathrm{react}}$,
         from weak reactions only as they are the only contributing
         reactions in NSE.
@@ -85,7 +85,7 @@ Here we give outline on how the reactive update is done with NSE.
         .. math::
            m_k c^2 = (A_k - Z_k) m_n c^2 + Z_k (m_p + m_e) c^2 - B_k
 
-      * The full reactive source term, $[\Rb(\rho e)}]^n$ is then:
+      * The full reactive source term, $[\Rb(\rho e)]^n$ is then:
 
         .. math::
            [\Rb(\rho e)]^n = [\Rb(\rho e)_{\mathrm{nuc}}]^n - [\rho]^n \left(\epsilon_{\nu,\mathrm{thermal}} + \epsilon_{\nu,\mathrm{react}}\right)

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -50,7 +50,7 @@ Here we give outline on how the reactive update is done with NSE.
 
       .. math::
 
-         \Advs{Y_e} = \sum_k \frac{Z_k}{A_k} \Advs{\rho X_k}
+         \Advs{\rho Y_e} = \sum_k \frac{Z_k}{A_k} \Advs{\rho X_k}
 
     * Compute $[\Rb(\rho Y_e)]^n$ and $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ using
       $[\rho]^n$, $[T]^n$, $[Y_e]^n$ and $[e]^n$:
@@ -73,12 +73,12 @@ Here we give outline on how the reactive update is done with NSE.
       * Evaluate $[\Rb(\rho Y_e)]^n$ as:
 
         .. math::
-           [\Rb(\rho Y_e)]^n = [\rho]^n \sum_k Z_k \dot{Y}_{\mathrm{k, weak}}
+           [\Rb(\rho Y_e)]^n = [\rho]^n \sum_k Z_k \dot{Y}_{\mathrm{k, weak}}^n
 
       * Evaluate $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ as:
 
         .. math::
-           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \sum_k \dot{Y}_{\mathrm{k, weak}} m_k
+           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \sum_k \dot{Y}_{\mathrm{k, weak}}^n m_k
 
         where the nuclei mass, $m_k$ is defined as:
 
@@ -93,7 +93,7 @@ Here we give outline on how the reactive update is done with NSE.
     * Now evolve $\rho$, $\rho e$, and $\rho Y_e$ to midpoint in time:
 
       .. math::
-         \Uc^{\prime,n+1/2} = \Uc^{\prime,n} + \frac{\Delta t}{2} \left([\Advs{\Uc^\prime}]^{n+1/2} + [\Rb(\Uc^\prime)]^{n+1/2}\right)
+         \Uc^{\prime,n+1/2} = \Uc^{\prime,n} + \frac{\Delta t}{2} \left([\Advs{\Uc^\prime}]^{n} + [\Rb(\Uc^\prime)]^{n}\right)
 
       Note that there is no reactive source term for $\rho$ and the advective
       source term is constant throughout the reactive update.

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -73,12 +73,12 @@ Here we give outline on how the reactive update is done with NSE.
       * Evaluate $[\Rb(\rho Y_e)]^n$ as:
 
         .. math::
-           [\Rb(\rho Y_e)]^n = [\rho]^n \sum_k Z_k \dot{Y}_{\mathrm{k, weak}}^n
+           [\Rb(\rho Y_e)]^n = [\rho]^n \sum_k Z_k [\dot{Y}_{\mathrm{k, weak}}]^n
 
       * Evaluate $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ as:
 
         .. math::
-           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \sum_k \dot{Y}_{\mathrm{k, weak}}^n m_k
+           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \sum_k [\dot{Y}_{\mathrm{k, weak}}]^n m_k
 
         where the nuclei mass, $m_k$ is defined as:
 
@@ -102,7 +102,7 @@ Here we give outline on how the reactive update is done with NSE.
       $[\Rb(\rho e)_{\mathrm{nuc}}]^{n+1/2}$ following the same
       procedure as above. This time, it uses
       $[\rho]^{n+1/2}$, $[Y_e]^{n+1/2}$ and $[e]^{n+1/2}$ as input
-      and uses the updated $[T]^n$ as initial guess for the inversion
+      and uses the updated $[T]^n$ as initial guess for the EOS inversion
       algorithm.
 
     * Now evolve all thermodynamic quantities to new time, $t^{n+1}$, using the

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -50,7 +50,7 @@ Here we give outline on how the reactive update is done with NSE.
 
       .. math::
 
-         \Advs{Y_e} = \Sigma_k \frac{Z_k}{A_k} \Advs{\rho X_k}
+         \Advs{Y_e} = \sum_k \frac{Z_k}{A_k} \Advs{\rho X_k}
 
     * Compute $[\Rb(\rho Y_e)]^n$ and $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ using
       $[\rho]^n$, $[T]^n$, $[Y_e]^n$ and $[e]^n$:
@@ -73,12 +73,12 @@ Here we give outline on how the reactive update is done with NSE.
       * Evaluate $[\Rb(\rho Y_e)]^n$ as:
 
         .. math::
-           [\Rb(\rho Y_e)]^n = [\rho]^n \Sigma_k Z_k \dot{Y}_{\mathrm{k, weak}}
+           [\Rb(\rho Y_e)]^n = [\rho]^n \sum_k Z_k \dot{Y}_{\mathrm{k, weak}}
 
       * Evaluate $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ as:
 
         .. math::
-           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \Sigma_k \dot{Y}_{\mathrm{k, weak}} m_k
+           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \sum_k \dot{Y}_{\mathrm{k, weak}} m_k
 
         where the nuclei mass, $m_k$ is defined as:
 

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -15,9 +15,11 @@ under the assumption of NSE, following the procedure outlined in :cite:`Calder_2
    (like ``aprox13``).  You should use a pynucastro-generated network.
 
 There are two methods for solving the chemical potentials:
+
 1. Hybrid Powell's method. This is the default method.
    This algorithm is taken from MINPACK and
    ported to templated C++.
+
 2. Newton-Raphson (NR) method.
    This method is not as robust compared
    to the Hybrid Powell's method through our testings.

--- a/Docs/source/nse_net.rst
+++ b/Docs/source/nse_net.rst
@@ -14,11 +14,18 @@ under the assumption of NSE, following the procedure outlined in :cite:`Calder_2
    Self-consistent NSE does not support the templated C++ networks
    (like ``aprox13``).  You should use a pynucastro-generated network.
 
-The solve is done using a port of the hybrid Powell method from
-MINPACK (we ported the solver to templated C++).
+There are two methods for solving the chemical potentials:
+1. Hybrid Powell's method. This is the default method.
+   This algorithm is taken from MINPACK and
+   ported to templated C++.
+2. Newton-Raphson (NR) method.
+   This method is not as robust compared
+   to the Hybrid Powell's method through our testings.
+   But this can be enabled via runtime parameter:
+   ``nse.use_hybrid_solver=0``.
 
-The advantage of this approach is that it can be used with any
-reaction network, once the integration has reached NSE.
+The advantage of this approach is that it can be used with any reaction network,
+once the integration has reached NSE.
 
 This solver is enabled by compiling with
 
@@ -27,6 +34,88 @@ This solver is enabled by compiling with
    USE_NSE_NET=TRUE
 
 The functions to find the NSE state are then found in ``nse_solver.H``.
+
+NSE Reactive Update
+===================
+
+Here we give outline on how the reactive update is done with NSE.
+
+* Check if NSE applies (see below)
+
+  * If we are in an NSE region:
+
+    * Compute the advective source term for $Y_e$ via:
+
+      .. math::
+
+         \Advs{Y_e} = \Sigma_k \frac{Z_k}{A_k} \Advs{\rho X_k}
+
+    * Compute $[\Rb(\rho Y_e)]^n$ and $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ using
+      $[\rho]^n$, $[T]^n$, $[Y_e]^n$ and $[e]^n$:
+
+      * Find the NSE composition with given $[\rho]^n$, $[e]^n$,
+        and $[Y_e]^n$. An EOS inversion algorithm is used so
+        that we determine $[T^*]^n$ such that $[e]^n$ remains
+        unchanged after switching to the NSE composition.
+        Here we use $[T]^n$ as the initial guess and updated
+        to the solution, $[T^*]^n$, in the end.
+
+      * Compute the thermal neutrino losses,
+        $\epsilon_{\nu,\mathrm{thermal}}$, using the NSE composition.
+
+      * Evaluate $\dot{Y}_{\mathrm{weak}} and neutrino losses,
+        $\epsilon_{\nu,\mathrm{react}}$,
+        from weak reactions only as they are the only contributing
+        reactions in NSE.
+
+      * Evaluate $[\Rb(\rho Y_e)]^n$ as:
+
+        .. math::
+           [\Rb(\rho Y_e)]^n = [\rho]^n \Sigma_k Z_k \dot{Y}_{\mathrm{k, weak}}
+
+      * Evaluate $[\Rb(\rho e)_{\mathrm{nuc}}]^n$ as:
+
+        .. math::
+           [\Rb(\rho e)_{\mathrm{nuc}}]^n = - N_A c^2 \Sigma_k \dot{Y}_{\mathrm{k, weak}} m_k
+
+        where the nuclei mass, $m_k$ is defined as:
+
+        .. math::
+           m_k c^2 = (A_k - Z_k) m_n c^2 + Z_k (m_p + m_e) c^2 - B_k
+
+      * The full reactive source term, $[\Rb(\rho e)}]^n$ is then:
+
+        .. math::
+           [\Rb(\rho e)]^n = [\Rb(\rho e)_{\mathrm{nuc}}]^n - [\rho]^n \left(\epsilon_{\nu,\mathrm{thermal}} + \epsilon_{\nu,\mathrm{react}}\right)
+
+    * Now evolve $\rho$, $\rho e$, and $\rho Y_e$ to midpoint in time:
+
+      .. math::
+         \Uc^{\prime,n+1/2} = \Uc^{\prime,n} + \frac{\Delta t}{2} \left([\Advs{\Uc^\prime}]^{n+1/2} + [\Rb(\Uc^\prime)]^{n+1/2}\right)
+
+      Note that there is no reactive source term for $\rho$ and the advective
+      source term is constant throughout the reactive update.
+
+    * Compute $[\Rb(\rho Y_e)]^{n+1/2}$ and
+      $[\Rb(\rho e)_{\mathrm{nuc}}]^{n+1/2}$ following the same
+      procedure as above. This time, it uses
+      $[\rho]^{n+1/2}$, $[Y_e]^{n+1/2}$ and $[e]^{n+1/2}$ as input
+      and uses the updated $[T]^n$ as initial guess for the inversion
+      algorithm.
+
+    * Now evolve all thermodynamic quantities to new time, $t^{n+1}$, using the
+      midpoint reactive source terms constructed in the previous step.
+
+      .. math::
+
+         \Uc^{\prime,n+1} = \Uc^{\prime,n} + \Delta t \left([\Advs{\Uc^\prime}]^{n+1/2} + [\Rb(\Uc^\prime)]^{n+1/2}\right)
+
+    * Lastly, the composition is updated by finding the corresponding NSE state
+      using $[\rho]^{n+1}$, $[e]^{n+1}$, and $[Y_e]^{n+1}$
+
+  * If we are not in an NSE region:
+
+    * Integrate the network as usual.
 
 Dynamic NSE Check
 =================

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -309,24 +309,22 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 ///
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
-                const amrex::Real rhoYe0, const amrex::Real T_old,
+                const amrex::Real rhoYe0, amrex::Real &T0,
                 amrex::Real &mu_p, amrex::Real &mu_n,
                 amrex::Real &drhoyedt_weak, amrex::Real& drhoedt,
                 const amrex::Real T_fixed) {
 
     // start with the current state and compute T
 
-    amrex::Real T0;
     amrex::Real Ye0 = rhoYe0 / rho0;
     amrex::Real abar{0.0_rt};
 
-    // Get initial temperature and abar for
+    // Get initial temperature.
 
     if (T_fixed > 0) {
         T0 = T_fixed;
     } else {
-        // initial guess for eos
-        T0 = T_old;
+        // updates T0 to be consistent with e0 and NSE
         amrex::Real e0 = rhoe0 / rho0;
         nse_T_abar_from_e(rho0, e0, Ye0, T0, abar, mu_p, mu_n);
     }

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -310,9 +310,8 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
                 const amrex::Real rhoYe0, const amrex::Real T_old,
-                const amrex::Real dt, amrex::Real &mu_p, amrex::Real &mu_n,
-                amrex::Real &drhoyedt_weak, const amrex::Real drhoyedt_a,
-                const amrex::Real *ydot_a, amrex::Real& drhoedt,
+                amrex::Real &mu_p, amrex::Real &mu_n,
+                amrex::Real &drhoyedt_weak, amrex::Real& drhoedt,
                 const amrex::Real T_fixed) {
 
     // start with the current state and compute T
@@ -457,10 +456,9 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 
     nse_derivs(rho_old, rhoe_old,
                rhoye_old, T_old,
-               dt, mu_p, mu_n,
-               drhoyedt_weak, drhoyedt_a,
-               state.ydot_a,
-               drhoedt, state.T_fixed);
+               mu_p, mu_n,
+               drhoyedt_weak, drhoedt,
+               state.T_fixed);
 
     // evolve to the midpoint in time
 
@@ -472,10 +470,9 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 
     nse_derivs(rho_tmp, rhoe_tmp,
                rhoye_tmp, T_old,
-               dt, mu_p, mu_n,
-               drhoyedt_weak, drhoyedt_a,
-               state.ydot_a,
-               drhoedt, state.T_fixed);
+               mu_p, mu_n,
+               drhoyedt_weak, drhoedt,
+               state.T_fixed);
 
     // evolve to the new time
 

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -349,27 +349,22 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
 
     auto nse_state0 = get_actual_nse_state(burn_state, 1.0e-10_rt, true);
 
-    // Still need to get abar for T_fixed > 0
-
-    if (T_fixed > 0) {
-        for (int n = 0; n < NumSpec; ++n) {
-            abar += nse_state0.xn[n] * aion_inv[n];
-        }
-        abar = 1.0_rt / abar;
-    }
-
+#ifdef NEUTRINOS
     // compute the plasma neutrino losses
-    // here abar should already be in-sync with NSE
+
+    // Get abar
+    for (int n = 0; n < NumSpec; ++n) {
+        abar += nse_state0.xn[n] * aion_inv[n];
+    }
+    abar = 1.0_rt / abar;
 
     amrex::Real snu{0.0_rt};
     amrex::Real dsnudt{0.0_rt};
     amrex::Real dsnudd{0.0_rt};
     amrex::Real dsnuda{0.0_rt};
     amrex::Real dsnudz{0.0_rt};
-
     amrex::Real zbar = abar * Ye0;
 
-#ifdef NEUTRINOS
     {
         constexpr int do_derivatives = 0;
         sneut5<do_derivatives>(T0, rho0, abar, zbar,
@@ -421,6 +416,8 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
         rhoe_source += rho0 * e_nu;
     }
 
+    drhoedt = rhoe_source;
+    return;
     //
     // evolve for eps * dt;
     //
@@ -469,7 +466,6 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
     drhoedt *= C::enuc_conv2 / tau;
 
     // include neutrino terms again
-    // I should probably update snu and enu here?
 
     drhoedt -= rho1 * snu;
     if (integrator_rp::nse_include_enu_weak == 1) {

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -506,21 +506,11 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 
     auto nse_state = get_actual_nse_state(burn_state, 1.0e-10_rt, true);
 
-    // store the new state
-    // make sure they are normalized
-
-    amrex::Real sum_X{0.0_rt};
-    for (auto & xn : nse_state.xn) {
-        xn = amrex::Clamp(xn, small_x, 1.0_rt);
-        sum_X += xn;
-    }
-
-    for (auto & xn : nse_state.xn) {
-        xn /= sum_X;
-    }
+    // Update rho X using new NSE state
+    // These should be already normalized due to NSE constraint
 
     for (int n = 0; n < NumSpec; ++n) {
-        state.y[SFS+n] = rho_new * nse_state.xn[n];
+        state.y[SFS+n] = rho_new * nse_state.y[SFS+n];
     }
 
     // Update total and internal energy.

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -469,6 +469,7 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
     drhoedt *= C::enuc_conv2 / tau;
 
     // include neutrino terms again
+    // I should probably update snu and enu here?
 
     drhoedt -= rho1 * snu;
     if (integrator_rp::nse_include_enu_weak == 1) {
@@ -516,7 +517,7 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
     amrex::Real drhoyedt_weak{0.0_rt};
     amrex::Real drhoyedt_a{0.0_rt};
 
-    // find the advection contribution: drhoyedt_a and drhoabardt_a
+    // find the advection contribution: drhoyedt_a
 
     for (int n = 0; n < NumSpec; ++n) {
         drhoyedt_a += state.ydot_a[SFS+n] * zion[n] * aion_inv[n];

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -305,16 +305,13 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 /// Self-Consistent NSE VERSION
 
 ///
-/// this acts as an explicit Euler step for the system (rho e, rho)
-/// on input, *_source are the reactive sources at time t0 and on output
-/// they are the sources at time t0+dt
+/// This computes drhoedt and drhoyedt_weak for a given (rho, rho e, and rho Ye)
 ///
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
                 const amrex::Real rhoYe0, const amrex::Real T_old,
                 const amrex::Real dt, amrex::Real &mu_p, amrex::Real &mu_n,
                 amrex::Real &drhoyedt_weak, const amrex::Real drhoyedt_a,
-                amrex::Array1D<amrex::Real, 1, neqs> &ydot_weak,
                 const amrex::Real *ydot_a, amrex::Real& drhoedt,
                 const amrex::Real T_fixed) {
 
@@ -384,11 +381,8 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
 
     // Fill in ydot with only weak rates contributing
 
+    amrex::Array1D<amrex::Real, 1, neqs> ydot_weak;
     get_ydot_weak(nse_state0, ydot_weak, e_nu, Y);
-
-    ///
-    /// construct initial sources at t0
-    ///
 
     // Find drhoyedt_weak from weak reaction
 
@@ -397,81 +391,24 @@ void nse_derivs(const amrex::Real rho0, const amrex::Real rhoe0,
         drhoyedt_weak += rho0 * zion[n] * ydot_weak(n+1);
     }
 
-    // find rhoe_source
+    // Find drhoedt
 
-    amrex::Real rhoe_source{0.0_rt};
+    drhoedt = 0.0_rt;
     for (int n = 1; n <= NumSpec; ++n) {
-        rhoe_source += rho0 * ydot_weak(n) * network::mion(n);
+        drhoedt += rho0 * ydot_weak(n) * network::mion(n);
     }
-    rhoe_source *= C::enuc_conv2;
+    drhoedt *= C::enuc_conv2;
 
     // include plasma neutrino terms
 
-    rhoe_source -= rho0 * snu;
+    drhoedt -= rho0 * snu;
 
     // include neutrino loss terms from weak rates
     // Note that e_nu here is already negative so we add here.
 
     if (integrator_rp::nse_include_enu_weak == 1) {
-        rhoe_source += rho0 * e_nu;
+        drhoedt += rho0 * e_nu;
     }
-
-    drhoedt = rhoe_source;
-    return;
-    //
-    // evolve for eps * dt;
-    //
-
-    amrex::Real tau = integrator_rp::nse_deriv_dt_factor * dt;
-
-    amrex::Real rho1 = rho0 + tau * ydot_a[SRHO];
-    amrex::Real rhoe1 = rhoe0 + tau * (ydot_a[SEINT] + rhoe_source);
-    amrex::Real rhoYe1 = rhoYe0 + tau * (drhoyedt_weak + drhoyedt_a);
-
-    // compute the temperature at t0 + tau
-
-    amrex::Real T1;
-    amrex::Real Ye1 = rhoYe1 / rho1;
-
-    if (T_fixed > 0) {
-        T1 = T_fixed;
-    } else {
-        // initial guess for eos
-        T1 = T0;
-        amrex::Real e1 = rhoe1 / rho1;
-        amrex::Real abar1;
-        nse_T_abar_from_e(rho1, e1, Ye1, T1, abar1, mu_p, mu_n);
-    }
-
-    // update burn_state at t0 + tau
-
-    burn_state.T = T1;
-    burn_state.rho = rho1;
-    burn_state.y_e = Ye1;
-
-    // call NSE at t0 + tau with
-
-    // Note this new NSE state has advection contribution
-
-    auto nse_state1 = get_actual_nse_state(burn_state, 1.0e-10_rt, true);
-
-    // construct the finite-difference approximation to the derivatives
-    // subtract off advection contribution to get pure drhoedt from reaction
-
-    drhoedt = 0.0_rt;
-    for (int n = 0; n < NumSpec; ++n) {
-        drhoedt += (nse_state1.y[SFS+n] - tau * ydot_a[SFS+n] -
-                    nse_state0.y[SFS+n]) * aion_inv[n] * network::mion(n+1);
-    }
-    drhoedt *= C::enuc_conv2 / tau;
-
-    // include neutrino terms again
-
-    drhoedt -= rho1 * snu;
-    if (integrator_rp::nse_include_enu_weak == 1) {
-        drhoedt += rho1 * e_nu;
-    }
-
 }
 
 
@@ -506,24 +443,23 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
 
     // do an RK2 integration
 
-    // get the derivatives, rho_dyedt, drhoedt, ydot_weak at t = t^n
-
-    amrex::Array1D<amrex::Real, 1, neqs> ydot_weak;
     amrex::Real drhoedt{0.0_rt};
     amrex::Real drhoyedt_weak{0.0_rt};
     amrex::Real drhoyedt_a{0.0_rt};
 
-    // find the advection contribution: drhoyedt_a
+    // find the advection contribution for ye: drhoyedt_a
 
     for (int n = 0; n < NumSpec; ++n) {
         drhoyedt_a += state.ydot_a[SFS+n] * zion[n] * aion_inv[n];
     }
 
+    // get the derivatives, drhoyedt_weak and drhoedt at t = t^n
+
     nse_derivs(rho_old, rhoe_old,
                rhoye_old, T_old,
                dt, mu_p, mu_n,
                drhoyedt_weak, drhoyedt_a,
-               ydot_weak, state.ydot_a,
+               state.ydot_a,
                drhoedt, state.T_fixed);
 
     // evolve to the midpoint in time
@@ -538,7 +474,7 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
                rhoye_tmp, T_old,
                dt, mu_p, mu_n,
                drhoyedt_weak, drhoyedt_a,
-               ydot_weak, state.ydot_a,
+               state.ydot_a,
                drhoedt, state.T_fixed);
 
     // evolve to the new time
@@ -590,15 +526,11 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
         state.y[SFS+n] = rho_new * nse_state.xn[n];
     }
 
-    // density and momenta have already been updated
-
-    // get the energy release from the change in rhoe over the timestep
-    // excluding any advection, and use that to update the total energy
-
-    amrex::Real rho_enucdot = (rhoe_new - rhoe_old) / dt - state.ydot_a[SEINT];
+    // Update total and internal energy.
+    // Note that density and momenta have already been updated before.
 
     state.y[SEINT] = rhoe_new;
-    state.y[SEDEN] += dt * state.ydot_a[SEDEN] + dt * rho_enucdot;
+    state.y[SEDEN] += dt * (state.ydot_a[SEDEN] + drhoedt);
 
     // store the chemical potentials
 

--- a/integration/nse_update_sdc.H
+++ b/integration/nse_update_sdc.H
@@ -510,7 +510,7 @@ void sdc_nse_burn(BurnT& state, const amrex::Real dt) {
     // These should be already normalized due to NSE constraint
 
     for (int n = 0; n < NumSpec; ++n) {
-        state.y[SFS+n] = rho_new * nse_state.y[SFS+n];
+        state.y[SFS+n] = nse_state.y[SFS+n];
     }
 
     // Update total and internal energy.

--- a/nse_solver/nse_eos.H
+++ b/nse_solver/nse_eos.H
@@ -33,6 +33,8 @@ amrex::Real nse_abar(const amrex::Real T, const amrex::Real rho,
         abar += nse_state.xn[n] * aion_inv[n];
     }
 
+    abar = 1.0_rt / abar;
+
     // update mu_p and mu_n
 
     mu_p = burn_state.mu_p;
@@ -57,16 +59,16 @@ amrex::Real nse_dabar_dT(const amrex::Real T, const amrex::Real rho,
 
     // Calculate derivative using five-point stencil method
 
-    amrex::Real dabar_dT = (-nse_abar(T + 2.0_rt*dT, rho, Ye, mu_p, mu_n) +
-                             8.0_rt * nse_abar(T+dT, rho, Ye, mu_p, mu_n) -
-                             8.0_rt * nse_abar(T-dT, rho, Ye, mu_p, mu_n) +
-                             nse_abar(T - 2.0_rt*dT, rho, Ye, mu_p, mu_n)
-                            ) / (12.0_rt * dT);
+    // amrex::Real dabar_dT = (-nse_abar(T + 2.0_rt*dT, rho, Ye, mu_p, mu_n) +
+    //                          8.0_rt * nse_abar(T+dT, rho, Ye, mu_p, mu_n) -
+    //                          8.0_rt * nse_abar(T-dT, rho, Ye, mu_p, mu_n) +
+    //                          nse_abar(T - 2.0_rt*dT, rho, Ye, mu_p, mu_n)
+    //                         ) / (12.0_rt * dT);
 
     // Calculate derivative using central differencing
 
-    // amrex::Real dabar_dT = 0.5_rt * (nse_abar(T + dT, rho, Ye, mu_p, mu_n) -
-    //                                  nse_abar(T - dT, rho, Ye, mu_p, mu_n)) / dT;
+    amrex::Real dabar_dT = 0.5_rt * (nse_abar(T + dT, rho, Ye, mu_p, mu_n) -
+                                     nse_abar(T - dT, rho, Ye, mu_p, mu_n)) / dT;
 
     return dabar_dT;
 }

--- a/unit_test/nse_net_cell/ci-benchmarks/nse_net_unit_test.out
+++ b/unit_test/nse_net_cell/ci-benchmarks/nse_net_unit_test.out
@@ -1,5 +1,5 @@
-Initializing AMReX (24.10-178-g5a2390e00837)...
-AMReX (24.10-178-g5a2390e00837) initialized
+Initializing AMReX (23.05-831-gdf1e7d01d26d)...
+AMReX (23.05-831-gdf1e7d01d26d) initialized
 starting the single zone burn...
 reading in network electron-capture / beta-decay tables...
 chemical potential of proton is -3
@@ -32,7 +32,7 @@ Cr48 : 0.009963894349
 Fe52 : 0.05965978097
 Ni56 : 0.2350347653
 We're in NSE. 
-change in T: 6000000000 6069004547
-change in abar: 6.978477326 6.209857538
-recovered energy: 2.785016846e+18 2.785016852e+18
-AMReX (24.10-178-g5a2390e00837) finalized
+change in T: 6000000000 6069004550
+change in abar: 6.978477326 6.209857798
+recovered energy: 2.785016852e+18 2.785016852e+18
+AMReX (23.05-831-gdf1e7d01d26d) finalized


### PR DESCRIPTION
Addresses the following:
1) Fix the issue that abar wasn't calculated correctly. Needed to take the reciprocal in the end.
2) Switch to use central difference rather than 5-stencil to compute dabardT. Convergence test shows that central difference is sufficient for 2nd order.
3) Construct the reactive source term for rho e directly, instead of evolving for tau and do a finite difference to get the derivative.