### PR TITLE
allow hybrj to take jacobian and constraint eqs as input

### DIFF
--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -188,8 +188,9 @@ void apply_nse_exponent(T& nse_state,
 
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void fcn(amrex::Array1D<amrex::Real, 1, 2>& x, amrex::Array1D<amrex::Real, 1, 2>& fvec,
-         const nse_solver_data<T>& state_data, int& iflag) {
+void nse_fcn(amrex::Array1D<amrex::Real, 1, 2>& x,
+             amrex::Array1D<amrex::Real, 1, 2>& fvec,
+             const nse_solver_data<T>& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 
     amrex::ignore_unused(iflag);
@@ -226,8 +227,9 @@ void fcn(amrex::Array1D<amrex::Real, 1, 2>& x, amrex::Array1D<amrex::Real, 1, 2>
 
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void jcn(amrex::Array1D<amrex::Real, 1, 2>& x, amrex::Array2D<amrex::Real, 1, 2, 1, 2>& fjac,
-         const nse_solver_data<T>& state_data, int& iflag) {
+void nse_jcn(amrex::Array1D<amrex::Real, 1, 2>& x,
+             amrex::Array2D<amrex::Real, 1, 2, 1, 2>& fjac,
+             const nse_solver_data<T>& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 
     amrex::ignore_unused(iflag);
@@ -312,8 +314,8 @@ void nse_hybrid_solver(nse_solver_data<T>& state_data,
             hj.x(1) = inner_x(1);
             hj.x(2) = inner_x(2);
 
-            // hybrj<2, T>(hj, state, fcn_hybrid<T>, jcn_hybrid<T>);
-            hybrj(hj, state_data);
+            hybrj<2, T>(hj, state, nse_fcn<2, T>, nse_jcn<2, T>);
+            // hybrj(hj, state_data);
 
             fcn(hj.x, f, state_data, flag);
 

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -190,7 +190,7 @@ template <int neqs, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_fcn(amrex::Array1D<amrex::Real, 1, neqs>& x,
              amrex::Array1D<amrex::Real, 1, neqs>& fvec,
-             const nse_solver_data<T>& state_data, int& iflag) {
+             const T& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 
     amrex::ignore_unused(iflag);
@@ -229,7 +229,7 @@ template <int neqs, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void nse_jcn(amrex::Array1D<amrex::Real, 1, neqs>& x,
              amrex::Array2D<amrex::Real, 1, neqs, 1, neqs>& fjac,
-             const nse_solver_data<T>& state_data, int& iflag) {
+             const T& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 
     amrex::ignore_unused(iflag);

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -314,9 +314,7 @@ void nse_hybrid_solver(nse_solver_data<T>& state_data,
             hj.x(1) = inner_x(1);
             hj.x(2) = inner_x(2);
 
-            hybrj<2, T>(hj, state, nse_fcn<2, T>, nse_jcn<2, T>);
-            // hybrj(hj, state_data);
-
+            hybrj<2, T>(hj, state_data, nse_fcn<2, T>, nse_jcn<2, T>);
             fcn(hj.x, f, state_data, flag);
 
             if (std::abs(f(1)) < eps && std::abs(f(2)) < eps) {

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -315,7 +315,7 @@ void nse_hybrid_solver(nse_solver_data<T>& state_data,
             hj.x(2) = inner_x(2);
 
             hybrj<2, T>(hj, state_data, nse_fcn<2, T>, nse_jcn<2, T>);
-            fcn(hj.x, f, state_data, flag);
+            nse_fcn(hj.x, f, state_data, flag);
 
             if (std::abs(f(1)) < eps && std::abs(f(2)) < eps) {
 
@@ -383,8 +383,8 @@ void nse_nr_solver(nse_solver_data<T>& state_data,
     x(1) = state_data.state.mu_p;
     x(2) = state_data.state.mu_n;
 
-    jcn(x, jac, state_data, flag);
-    fcn(x, f, state_data, flag);
+    nse_jcn(x, jac, state_data, flag);
+    nse_fcn(x, f, state_data, flag);
 
     // store determinant for finding inverse jac
     amrex::Real det;
@@ -460,8 +460,8 @@ void nse_nr_solver(nse_solver_data<T>& state_data,
 
         // update constraint
 
-        jcn(x, jac, state_data, flag);
-        fcn(x, f, state_data, flag);
+        nse_jcn(x, jac, state_data, flag);
+        nse_fcn(x, f, state_data, flag);
     }
 
     if (!converged) {

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -314,7 +314,10 @@ void nse_hybrid_solver(nse_solver_data<T>& state_data,
             hj.x(1) = inner_x(1);
             hj.x(2) = inner_x(2);
 
-            hybrj<2, T>(hj, state_data, nse_fcn<2, T>, nse_jcn<2, T>);
+            hybrj<2, nse_solver_data<T>>(hj, state_data,
+                                         nse_fcn<2, nse_solver_data<T>>,
+                                         nse_jcn<2, nse_solver_data<T>>);
+
             nse_fcn(hj.x, f, state_data, flag);
 
             if (std::abs(f(1)) < eps && std::abs(f(2)) < eps) {

--- a/nse_solver/nse_solver.H
+++ b/nse_solver/nse_solver.H
@@ -186,10 +186,10 @@ void apply_nse_exponent(T& nse_state,
 
 // constraint equation
 
-template <typename T>
+template <int neqs, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void nse_fcn(amrex::Array1D<amrex::Real, 1, 2>& x,
-             amrex::Array1D<amrex::Real, 1, 2>& fvec,
+void nse_fcn(amrex::Array1D<amrex::Real, 1, neqs>& x,
+             amrex::Array1D<amrex::Real, 1, neqs>& fvec,
              const nse_solver_data<T>& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 
@@ -225,10 +225,10 @@ void nse_fcn(amrex::Array1D<amrex::Real, 1, 2>& x,
 
 // constraint jacobian
 
-template <typename T>
+template <int neqs, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void nse_jcn(amrex::Array1D<amrex::Real, 1, 2>& x,
-             amrex::Array2D<amrex::Real, 1, 2, 1, 2>& fjac,
+void nse_jcn(amrex::Array1D<amrex::Real, 1, neqs>& x,
+             amrex::Array2D<amrex::Real, 1, neqs, 1, neqs>& fjac,
              const nse_solver_data<T>& state_data, int& iflag) {
     // here state is the nse_state from get_nonexponent_nse_state
 

--- a/util/hybrj/hybrj.H
+++ b/util/hybrj/hybrj.H
@@ -14,15 +14,19 @@
 template<int neqs, typename T>
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
 void hybrj(hybrj_t<neqs>& hj,
-           const T& data) {
+           const T& data,
+           void (*fcn)(amrex::Array1D<amrex::Real, 1, neqs>&,
+                       amrex::Array1D<amrex::Real, 1, neqs>&,
+                       const T&, int&),
+           void (*jcn)(amrex::Array1D<amrex::Real, 1, neqs>&,
+                       amrex::Array2D<amrex::Real, 1, neqs, 1, neqs>&,
+                       const T&, int&)
+           ) {
 
     // the purpose of hybrj is to find a zero of a system of
     // n nonlinear functions in n variables by a modification
     // of the powell hybrid method. the user must provide a
     // subroutine which calculates the functions and the jacobian.
-    //
-    // We require fcn and jcn to be defined in the other header file
-    // where we include this header.
     //
     // fcn jcn are the names of the user-supplied subroutine which
     // calculates the functions and the jacobian.

--- a/util/hybrj/test/GNUmakefile
+++ b/util/hybrj/test/GNUmakefile
@@ -5,13 +5,13 @@ DEBUG      = FALSE
 
 DIM        = 3
 
-COMP	   = gnu
+COMP       = gnu
 
 USE_MPI    = FALSE
 USE_OMP    = FALSE
 
 USE_REACT = TRUE
-
+USE_SIMPLIFIED_SDC = TRUE
 USE_NSE_NET = TRUE
 EBASE = main
 
@@ -23,6 +23,8 @@ EOS_DIR     := helmholtz
 
 # This sets the network directory
 NETWORK_DIR := aprox21
+
+SCREEN_METHOD = chabrier1998
 
 CONDUCTIVITY_DIR := stellar
 
@@ -38,5 +40,3 @@ Bpack   := ../Make.package ./Make.package
 Blocs   := ../ .
 
 include $(MICROPHYSICS_HOME)/unit_test/Make.unit_test
-
-

--- a/util/hybrj/test/main.cpp
+++ b/util/hybrj/test/main.cpp
@@ -14,7 +14,7 @@ int main() {
         hj.x(j) = -1.0;
     }
 
-    hj.xtol = std::sqrt(std::numeric_limits<Real>::epsilon());
+    hj.xtol = std::sqrt(std::numeric_limits<amrex::Real>::epsilon());
     hj.mode = 2;
 
     for (int j = 1; j <= neqs; ++j) {
@@ -23,10 +23,9 @@ int main() {
 
     // we'll pass a single Real as the extra data, but it can be any type
 
-    Real x{-3.14159};
+    amrex::Real x{-3.14159};
 
-    // hybrj(hj, x, fcn<neqs, Real>, jcn<neqs, Real>);
-    hybrj(hj, x);
+    hybrj<neqs, amrex::Real>(hj, x, fcn<neqs, amrex::Real>, jcn<neqs, amrex::Real>);
 
     std::cout << "done! solution = " << std::endl;
     for (int j = 1; j <= neqs; ++j) {

--- a/util/hybrj/test/test_func.H
+++ b/util/hybrj/test/test_func.H
@@ -2,15 +2,16 @@
 #define TEST_FUNC_H
 
 template<int neqs, typename T>
-void fcn(Array1D<Real, 1, neqs>& x, Array1D<Real, 1, neqs>& fvec, const T& data, int& iflag) {
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void fcn(amrex::Array1D<amrex::Real, 1, neqs>& x, amrex::Array1D<amrex::Real, 1, neqs>& fvec, const T& data, int& iflag) {
 
     for (int k = 1; k <= neqs; ++k) {
-        Real temp = (3.0_rt - 2.0_rt * x(k)) * x(k);
-        Real temp1 = 0.0_rt;
+        amrex::Real temp = (3.0_rt - 2.0_rt * x(k)) * x(k);
+        amrex::Real temp1 = 0.0_rt;
         if (k != 1) {
             temp1 = x(k-1);
         }
-        Real temp2 = 0.0_rt;
+        amrex::Real temp2 = 0.0_rt;
         if (k != neqs) {
             temp2 = x(k+1);
         }
@@ -19,7 +20,8 @@ void fcn(Array1D<Real, 1, neqs>& x, Array1D<Real, 1, neqs>& fvec, const T& data,
 }
 
 template<int neqs, typename T>
-void jcn(Array1D<Real, 1, neqs>& x, Array2D<Real, 1, neqs, 1, neqs>& fjac, const T& data, int& iflag) {
+AMREX_GPU_HOST_DEVICE AMREX_INLINE
+void jcn(amrex::Array1D<amrex::Real, 1, neqs>& x, amrex::Array2D<amrex::Real, 1, neqs, 1, neqs>& fjac, const T& data, int& iflag) {
 
     for (int k = 1; k <= neqs; ++k) {
         for (int j = 1; j <= neqs; ++j) {


### PR DESCRIPTION
we relied on defining`fcn` and `jcn` as function name in other header files and hybrj automatically uses that. This was done in https://github.com/AMReX-Astro/Castro/pull/3088 since cuda doesn't like std::function as it complained we will be calling __host__ functions. 

But this pr seems to work.