### PR TITLE
add missing create_network + update import directions

### DIFF
--- a/Docs/source/networks.rst
+++ b/Docs/source/networks.rst
@@ -37,17 +37,14 @@ Microphysics knows the properties of the fluid.
    .. code:: python
 
       import os
-      import importlib
+      from pathlib import Path
+      import sys
 
       mp = os.getenv("MICROPHYSICS_HOME")
+      moddir = Path(mp) / "networks" / "CNO_extras"
+      sys.path.insert(0, str(moddir))
 
-      # change this to reflect the network you want
-      loc = f"{mp}/networks/CNO_extras/CNO_extras.py"
-
-      spec = importlib.util.spec_from_file_location("pynet", loc)
-      pynet = importlib.util.module_from_spec(spec)
-      spec.loader.exec_module(pynet)
-
+      import CNO_extras as pynet
       net = pynet.create_network()
 
    You can then work with the network through the ``net`` object, for instance

--- a/networks/he-burn/cno-he-burn-33a/cno_he_burn_33a.py
+++ b/networks/he-burn/cno-he-burn-33a/cno_he_burn_33a.py
@@ -6,10 +6,7 @@ from pynucastro.networks import AmrexAstroCxxNetwork
 import he_burn_core
 
 
-DO_DERIVED_RATES = True
-
-
-def doit():
+def create_network():
 
     extra_reactants = ["c13", "n14", "n15",
                        "o14", "o15", "o17", "o18",
@@ -21,7 +18,7 @@ def doit():
     subch = he_burn_core.get_core_library(include_n14_approx=False,
                                           include_zn=False,
                                           extra_nuclei=extra_reactants,
-                                          do_detailed_balance=DO_DERIVED_RATES)
+                                          do_detailed_balance=True)
 
     net = AmrexAstroCxxNetwork(libraries=[subch], symmetric_screening=False)
 
@@ -29,6 +26,12 @@ def doit():
                                                "v47", "mn51", "co55"])
     net.remove_nuclei(["cl35", "k39", "sc43", "v47", "mn51", "co55"])
 
+    return net
+
+
+def doit():
+
+    net = create_network()
     net.summary()
 
     comp = pyna.Composition(net.get_nuclei())


### PR DESCRIPTION
the docs now show a more robust way to import a network into python