### PR TITLE
Revert "move EOS data to be inline (#1937)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,8 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
     execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/util/build_scripts/write_probin.py" --pa "${EOSparamfile} ${networkparamfile}
                     ${VODEparamfile} ${integrationparamfile}" --use_namespace WORKING_DIRECTORY ${output_dir}/)
 
-    set(gamma_law_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
+    set(gamma_law_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
+                          ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
                           ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
     execute_process(COMMAND python3 "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/general_null/write_network.py" --header_template "${networkheadertemplatefile}" --header_output "${networkpropfile}" -s "${networkfile}" WORKING_DIRECTORY ${output_dir}/)
 
@@ -81,7 +82,9 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
                       ${networkparamfile} ${VODEparamfile} ${integrationparamfile} " --use_namespace WORKING_DIRECTORY ${output_dir}/)
     endif()
 
-    set(primordial_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
+    set(primordial_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS/primordial_chem/actual_eos_data.cpp
                                 ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/primordial_chem/actual_network_data.cpp
                                 ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
 
@@ -127,9 +130,11 @@ function(setup_target_for_microphysics_compilation network_name output_dir)
     endif()
 
     #unlike primordial chem, we also include actual_network_data.cpp here because it is in there that we read in the Semenov opacity table
-    set(metal_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
-                           ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/metal_chem/actual_network_data.cpp
-                           ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
+    set(metal_chem_sources ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/eos_data.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/interfaces/network_initialization.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/EOS/metal_chem/actual_eos_data.cpp
+                                ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/networks/metal_chem/actual_network_data.cpp
+                                ${output_dir}/extern_parameters.cpp PARENT_SCOPE)
 
 
     #below for NAUX

--- a/EOS/breakout/Make.package
+++ b/EOS/breakout/Make.package
@@ -1,2 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/breakout/actual_eos_data.H
+++ b/EOS/breakout/actual_eos_data.H
@@ -4,6 +4,6 @@
 #include <AMReX.H>
 #include <AMReX_REAL.H>
 
-inline AMREX_GPU_MANAGED amrex::Real gamma_const;
+extern AMREX_GPU_MANAGED amrex::Real gamma_const;
 
 #endif

--- a/EOS/breakout/actual_eos_data.cpp
+++ b/EOS/breakout/actual_eos_data.cpp
@@ -1,0 +1,3 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED amrex::Real gamma_const;

--- a/EOS/helmholtz/Make.package
+++ b/EOS/helmholtz/Make.package
@@ -1,2 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/helmholtz/actual_eos_data.H
+++ b/EOS/helmholtz/actual_eos_data.H
@@ -9,8 +9,8 @@ namespace helmholtz
 
     using namespace amrex::literals;
 
-    inline AMREX_GPU_MANAGED int do_coulomb;
-    inline AMREX_GPU_MANAGED int input_is_constant;
+    extern AMREX_GPU_MANAGED int do_coulomb;
+    extern AMREX_GPU_MANAGED int input_is_constant;
 
     // for the tables
 
@@ -26,34 +26,34 @@ namespace helmholtz
     constexpr amrex::Real dstp  = (dhi - dlo) / (static_cast<amrex::Real>(imax-1));
     constexpr amrex::Real dstpi = 1.0e0_rt / dstp;
 
-    inline AMREX_GPU_MANAGED amrex::Real d[imax];
-    inline AMREX_GPU_MANAGED amrex::Real t[jmax];
+    extern AMREX_GPU_MANAGED amrex::Real d[imax];
+    extern AMREX_GPU_MANAGED amrex::Real t[jmax];
 
-    inline AMREX_GPU_MANAGED amrex::Real ttol;
-    inline AMREX_GPU_MANAGED amrex::Real dtol;
+    extern AMREX_GPU_MANAGED amrex::Real ttol;
+    extern AMREX_GPU_MANAGED amrex::Real dtol;
 
     // for the helmholtz free energy tables
-    inline AMREX_GPU_MANAGED amrex::Real f[jmax][imax][9];
+    extern AMREX_GPU_MANAGED amrex::Real f[jmax][imax][9];
 
     // for the pressure derivative with density tables
-    inline AMREX_GPU_MANAGED amrex::Real dpdf[jmax][imax][4];
+    extern AMREX_GPU_MANAGED amrex::Real dpdf[jmax][imax][4];
 
     // for chemical potential tables
-    inline AMREX_GPU_MANAGED amrex::Real ef[jmax][imax][4];
+    extern AMREX_GPU_MANAGED amrex::Real ef[jmax][imax][4];
 
     // for the number density tables
-    inline AMREX_GPU_MANAGED amrex::Real xf[jmax][imax][4];
+    extern AMREX_GPU_MANAGED amrex::Real xf[jmax][imax][4];
 
     // for storing the differences
-    inline AMREX_GPU_MANAGED amrex::Real dt_sav[jmax];
-    inline AMREX_GPU_MANAGED amrex::Real dt2_sav[jmax];
-    inline AMREX_GPU_MANAGED amrex::Real dti_sav[jmax];
-    inline AMREX_GPU_MANAGED amrex::Real dt2i_sav[jmax];
+    extern AMREX_GPU_MANAGED amrex::Real dt_sav[jmax];
+    extern AMREX_GPU_MANAGED amrex::Real dt2_sav[jmax];
+    extern AMREX_GPU_MANAGED amrex::Real dti_sav[jmax];
+    extern AMREX_GPU_MANAGED amrex::Real dt2i_sav[jmax];
 
-    inline AMREX_GPU_MANAGED amrex::Real dd_sav[imax];
-    inline AMREX_GPU_MANAGED amrex::Real dd2_sav[imax];
-    inline AMREX_GPU_MANAGED amrex::Real ddi_sav[imax];
-    inline AMREX_GPU_MANAGED amrex::Real dd2i_sav[imax];
+    extern AMREX_GPU_MANAGED amrex::Real dd_sav[imax];
+    extern AMREX_GPU_MANAGED amrex::Real dd2_sav[imax];
+    extern AMREX_GPU_MANAGED amrex::Real ddi_sav[imax];
+    extern AMREX_GPU_MANAGED amrex::Real dd2i_sav[imax];
 
     // 2006 CODATA physical constants
     constexpr amrex::Real h = 6.6260689633e-27;

--- a/EOS/helmholtz/actual_eos_data.cpp
+++ b/EOS/helmholtz/actual_eos_data.cpp
@@ -1,0 +1,33 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED int helmholtz::do_coulomb;
+AMREX_GPU_MANAGED int helmholtz::input_is_constant;
+
+AMREX_GPU_MANAGED amrex::Real helmholtz::d[imax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::t[jmax];
+
+AMREX_GPU_MANAGED amrex::Real helmholtz::ttol;
+AMREX_GPU_MANAGED amrex::Real helmholtz::dtol;
+
+// for the helmholtz free energy tables
+AMREX_GPU_MANAGED amrex::Real helmholtz::f[jmax][imax][9];
+
+// for the pressure derivative with density tables
+AMREX_GPU_MANAGED amrex::Real helmholtz::dpdf[jmax][imax][4];
+
+// for chemical potential tables
+AMREX_GPU_MANAGED amrex::Real helmholtz::ef[jmax][imax][4];
+
+// for the number density tables
+AMREX_GPU_MANAGED amrex::Real helmholtz::xf[jmax][imax][4];
+
+// for storing the differences
+AMREX_GPU_MANAGED amrex::Real helmholtz::dt_sav[jmax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::dt2_sav[jmax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::dti_sav[jmax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::dt2i_sav[jmax];
+
+AMREX_GPU_MANAGED amrex::Real helmholtz::dd_sav[imax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::dd2_sav[imax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::ddi_sav[imax];
+AMREX_GPU_MANAGED amrex::Real helmholtz::dd2i_sav[imax];

--- a/EOS/metal_chem/Make.package
+++ b/EOS/metal_chem/Make.package
@@ -1,2 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/metal_chem/actual_eos_data.H
+++ b/EOS/metal_chem/actual_eos_data.H
@@ -5,7 +5,7 @@
 #include <AMReX_REAL.H>
 #include <network.H>
 
-inline AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
-inline AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];
+extern AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
+extern AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];
 
 #endif

--- a/EOS/metal_chem/actual_eos_data.cpp
+++ b/EOS/metal_chem/actual_eos_data.cpp
@@ -1,0 +1,4 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
+AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];

--- a/EOS/multigamma/Make.package
+++ b/EOS/multigamma/Make.package
@@ -1,2 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/multigamma/actual_eos_data.H
+++ b/EOS/multigamma/actual_eos_data.H
@@ -5,6 +5,6 @@
 #include <AMReX_REAL.H>
 #include <network.H>
 
-inline AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
+extern AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
 
 #endif

--- a/EOS/multigamma/actual_eos_data.cpp
+++ b/EOS/multigamma/actual_eos_data.cpp
@@ -1,0 +1,3 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];

--- a/EOS/polytrope/Make.package
+++ b/EOS/polytrope/Make.package
@@ -1,3 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
-
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/polytrope/actual_eos_data.H
+++ b/EOS/polytrope/actual_eos_data.H
@@ -4,11 +4,11 @@
 #include <AMReX.H>
 #include <AMReX_REAL.H>
 
-inline AMREX_GPU_MANAGED amrex::Real gamma_const;
-inline AMREX_GPU_MANAGED amrex::Real K_const;
-inline AMREX_GPU_MANAGED amrex::Real mu_e;
-inline AMREX_GPU_MANAGED int  polytrope;
-inline AMREX_GPU_MANAGED amrex::Real gm1;
-inline AMREX_GPU_MANAGED amrex::Real polytrope_index;
+extern AMREX_GPU_MANAGED amrex::Real gamma_const;
+extern AMREX_GPU_MANAGED amrex::Real K_const;
+extern AMREX_GPU_MANAGED amrex::Real mu_e;
+extern AMREX_GPU_MANAGED int  polytrope;
+extern AMREX_GPU_MANAGED amrex::Real gm1;
+extern AMREX_GPU_MANAGED amrex::Real polytrope_index;
 
 #endif

--- a/EOS/polytrope/actual_eos_data.cpp
+++ b/EOS/polytrope/actual_eos_data.cpp
@@ -1,0 +1,8 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED amrex::Real gamma_const;
+AMREX_GPU_MANAGED amrex::Real K_const;
+AMREX_GPU_MANAGED amrex::Real mu_e;
+AMREX_GPU_MANAGED int  polytrope;
+AMREX_GPU_MANAGED amrex::Real gm1;
+AMREX_GPU_MANAGED amrex::Real polytrope_index;

--- a/EOS/primordial_chem/Make.package
+++ b/EOS/primordial_chem/Make.package
@@ -1,3 +1,3 @@
 CEXE_headers += actual_eos.H
 CEXE_headers += actual_eos_data.H
-
+CEXE_sources += actual_eos_data.cpp

--- a/EOS/primordial_chem/actual_eos_data.H
+++ b/EOS/primordial_chem/actual_eos_data.H
@@ -5,7 +5,7 @@
 #include <AMReX_REAL.H>
 #include <network.H>
 
-inline AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
-inline AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];
+extern AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
+extern AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];
 
 #endif

--- a/EOS/primordial_chem/actual_eos_data.cpp
+++ b/EOS/primordial_chem/actual_eos_data.cpp
@@ -1,0 +1,4 @@
+#include <actual_eos_data.H>
+
+AMREX_GPU_MANAGED amrex::Real gammas[NumSpec];
+AMREX_GPU_MANAGED amrex::Real spmasses[NumSpec];

--- a/interfaces/Make.package
+++ b/interfaces/Make.package
@@ -5,6 +5,8 @@ CEXE_headers += eos_data.H
 CEXE_headers += eos_type.H
 CEXE_headers += eos_override.H
 
+CEXE_sources += eos_data.cpp
+
 CEXE_headers += network.H
 CEXE_headers += rhs_type.H
 CEXE_headers += tfactors.H

--- a/interfaces/eos_data.H
+++ b/interfaces/eos_data.H
@@ -8,23 +8,23 @@
 
 namespace EOSData
 {
-  inline bool initialized;
-  inline AMREX_GPU_MANAGED amrex::Real mintemp;
-  inline AMREX_GPU_MANAGED amrex::Real maxtemp;
-  inline AMREX_GPU_MANAGED amrex::Real mindens;
-  inline AMREX_GPU_MANAGED amrex::Real maxdens;
-  inline AMREX_GPU_MANAGED amrex::Real minx;
-  inline AMREX_GPU_MANAGED amrex::Real maxx;
-  inline AMREX_GPU_MANAGED amrex::Real minye;
-  inline AMREX_GPU_MANAGED amrex::Real maxye;
-  inline AMREX_GPU_MANAGED amrex::Real mine;
-  inline AMREX_GPU_MANAGED amrex::Real maxe;
-  inline AMREX_GPU_MANAGED amrex::Real minp;
-  inline AMREX_GPU_MANAGED amrex::Real maxp;
-  inline AMREX_GPU_MANAGED amrex::Real mins;
-  inline AMREX_GPU_MANAGED amrex::Real maxs;
-  inline AMREX_GPU_MANAGED amrex::Real minh;
-  inline AMREX_GPU_MANAGED amrex::Real maxh;
+  extern bool initialized;
+  extern AMREX_GPU_MANAGED amrex::Real mintemp;
+  extern AMREX_GPU_MANAGED amrex::Real maxtemp;
+  extern AMREX_GPU_MANAGED amrex::Real mindens;
+  extern AMREX_GPU_MANAGED amrex::Real maxdens;
+  extern AMREX_GPU_MANAGED amrex::Real minx;
+  extern AMREX_GPU_MANAGED amrex::Real maxx;
+  extern AMREX_GPU_MANAGED amrex::Real minye;
+  extern AMREX_GPU_MANAGED amrex::Real maxye;
+  extern AMREX_GPU_MANAGED amrex::Real mine;
+  extern AMREX_GPU_MANAGED amrex::Real maxe;
+  extern AMREX_GPU_MANAGED amrex::Real minp;
+  extern AMREX_GPU_MANAGED amrex::Real maxp;
+  extern AMREX_GPU_MANAGED amrex::Real mins;
+  extern AMREX_GPU_MANAGED amrex::Real maxs;
+  extern AMREX_GPU_MANAGED amrex::Real minh;
+  extern AMREX_GPU_MANAGED amrex::Real maxh;
 }
 
 #endif

--- a/interfaces/eos_data.cpp
+++ b/interfaces/eos_data.cpp
@@ -1,0 +1,21 @@
+#include <eos_data.H>
+
+// Declare extern variables
+
+bool EOSData::initialized;
+AMREX_GPU_MANAGED amrex::Real EOSData::mintemp;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxtemp;
+AMREX_GPU_MANAGED amrex::Real EOSData::mindens;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxdens;
+AMREX_GPU_MANAGED amrex::Real EOSData::minx;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxx;
+AMREX_GPU_MANAGED amrex::Real EOSData::minye;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxye;
+AMREX_GPU_MANAGED amrex::Real EOSData::mine;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxe;
+AMREX_GPU_MANAGED amrex::Real EOSData::minp;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxp;
+AMREX_GPU_MANAGED amrex::Real EOSData::mins;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxs;
+AMREX_GPU_MANAGED amrex::Real EOSData::minh;
+AMREX_GPU_MANAGED amrex::Real EOSData::maxh;


### PR DESCRIPTION
This is to reverse inline EOS data. HIP on frontier is not happy with it. I am not sure if there is a way around it. 