### PR TITLE
actual_network_data.cpp is not needed for pynucastro nets

### DIFF
--- a/networks/CNO_extras/actual_network_data.cpp
+++ b/networks/CNO_extras/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/ECSN/actual_network_data.cpp
+++ b/networks/ECSN/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/ase-iron-starlib/actual_network_data.cpp
+++ b/networks/he-burn/ase-iron-starlib/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/ase-iron/actual_network_data.cpp
+++ b/networks/he-burn/ase-iron/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/ase-test/actual_network_data.cpp
+++ b/networks/he-burn/ase-test/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/cno-he-burn-33a/actual_network_data.cpp
+++ b/networks/he-burn/cno-he-burn-33a/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/cno-he-burn-34am/actual_network_data.cpp
+++ b/networks/he-burn/cno-he-burn-34am/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/he-burn-19am/actual_network_data.cpp
+++ b/networks/he-burn/he-burn-19am/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/he-burn-28amnp/actual_network_data.cpp
+++ b/networks/he-burn/he-burn-28amnp/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/he-burn/he-burn-33am/actual_network_data.cpp
+++ b/networks/he-burn/he-burn-33am/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/ignition_reaclib/C-burn-simple/actual_network_data.cpp
+++ b/networks/ignition_reaclib/C-burn-simple/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/ignition_reaclib/URCA-medium/actual_network_data.cpp
+++ b/networks/ignition_reaclib/URCA-medium/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/ignition_reaclib/URCA-simple/actual_network_data.cpp
+++ b/networks/ignition_reaclib/URCA-simple/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/nova-li/actual_network_data.cpp
+++ b/networks/nova-li/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/nova/actual_network_data.cpp
+++ b/networks/nova/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/partition_test/actual_network_data.cpp
+++ b/networks/partition_test/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}

--- a/networks/sn160/actual_network_data.cpp
+++ b/networks/sn160/actual_network_data.cpp
@@ -1,6 +1,0 @@
-#include <actual_network.H>
-
-void actual_network_init()
-{
-
-}


### PR DESCRIPTION
we seem to have just forgotten to remove these files